### PR TITLE
German translation overhaul

### DIFF
--- a/OptiFineDoc/assets/minecraft/optifine/lang/de_DE.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/de_DE.lang
@@ -1,36 +1,38 @@
 # Contributors of German localization #
 #   ThexXTURBOXx (Collaborator of Reforged) 2016-2-29 ---- 2016-3-3
+#   RoiEXLab 2016-3-8
+#   violine1101 (German Minecraft Wiki admin) 2016-4-4
 
 # General
 of.general.ambiguous=Unklar
 of.general.custom=Anderes
 of.general.from=Von
-of.general.id=Id
+of.general.id=ID
 of.general.restart=Neustart
 of.general.smart=Fein
 
 # Message
-of.message.aa.shaders1=Antialiasing ist mit Shader-Effekten nicht kompatibel.
-of.message.aa.shaders2=Bitte deaktiviere Shader-Effekte um diese Einstellung zu aktivieren.
+of.message.aa.shaders1=Antialiasing ist nicht mit Shader-Effekten kompatibel.
+of.message.aa.shaders2=Bitte deaktiviere Shader-Effekte, um diese Einstellung zu aktivieren.
 
 of.message.af.shaders1=Anistropische Filterung ist nicht mit Shader-Effekten kompatibel.
-of.message.af.shaders2=Bitte deaktiviere Shader-Effekte um diese Einstellung zu aktivieren.
+of.message.af.shaders2=Bitte deaktiviere Shader-Effekte, um diese Einstellung zu aktivieren.
 
 of.message.fr.shaders1=Schnelles Rendern ist nicht mit Shader-Effekten kompatibel.
-of.message.fr.shaders2=Bitte deaktiviere Shader-Effekte um diese Einstellung zu aktivieren.
+of.message.fr.shaders2=Bitte deaktiviere Shader-Effekte, um diese Einstellung zu aktivieren.
 
 of.message.shaders.aa1=Antialiasing ist nicht mit Shader-Effekten kompatibel. 
-of.message.shaders.aa2=Bitte stelle Qualität -> Antialiasing auf AUS und starte das Spiel neu.
+of.message.shaders.aa2=Bitte deaktiviere Qualität -> Antialiasing und starte das Spiel neu.
 
 of.message.shaders.af1=Anistropische Filterung ist nicht mit Shader-Effekten kompatibel.
-of.message.shaders.af2=Bitte stelle Qualität -> Anistropische Filterung auf AUS.
+of.message.shaders.af2=Bitte deaktiviere Qualität -> Anistropische Filterung.
 
 of.message.shaders.fr1=Schnelles Rendern ist nicht mit Shader-Effekten kompatibel.
-of.message.shaders.fr2=Bitte stelle Leistung -> Schnelles Rendern auf AUS.
+of.message.shaders.fr2=Bitte deaktiviere Leistung -> Schnelles Rendern.
 
 of.message.newVersion=Eine neue Version von §eOptiFine§f ist verfügbar: §e%s§f
-of.message.java64Bit=Du kannst §e64-bit Java§f installieren, um die Leistung zu verbessern
-of.message.openglError=§eOpenGL Fehler§f: %s (%s)
+of.message.java64Bit=Du kannst die §e64-bit-Version von Java§f installieren, um die Leistung zu verbessern
+of.message.openglError=§eOpenGL-Fehler§f: %s (%s)
 
 of.message.shaders.loading=Lade Shader-Effekte: %s
 
@@ -38,99 +40,104 @@ of.message.other.reset=Alle Videoeinstellungen auf die Standardwerte zurücksetz
  
 # Video settings
 
-options.graphics.tooltip.1=Visuelle Qualität
+options.graphics.tooltip.1=Grafikmodus
 options.graphics.tooltip.2=  Schnell - Schlechtere Qualität, schneller
 options.graphics.tooltip.3=  Schön   - Höhere Qualität, langsamer
-options.graphics.tooltip.4=Verändert das Aussehen der Wolken, Blätter, Grasseiten,
+options.graphics.tooltip.4=Verändert das Aussehen der Wolken, Blätter, Grasblöcke,
 options.graphics.tooltip.5=Schatten und von Wasser.
 
 of.options.renderDistance.extreme=Extrem
 
-options.renderDistance.tooltip.1=Sehbare Distanz
+options.renderDistance.tooltip.1=Sichtweite
 options.renderDistance.tooltip.2=  2 Mini - 32m (am schnellsten)
 options.renderDistance.tooltip.3=  4 Klein - 64m (schnell)
 options.renderDistance.tooltip.4=  8 Normal - 128m
 options.renderDistance.tooltip.5=  16 Weit - 256m (langsam)
 options.renderDistance.tooltip.6=  32 Extrem - 512m (am langsamsten!)
-options.renderDistance.tooltip.7=Die extreme sehbare Distanz ist sehr ressourcenaufwendig!
-options.renderDistance.tooltip.8=Werte über 16 Weit sind nur in lokalen Welten effektiv.
+options.renderDistance.tooltip.7=Die extreme Sichtweite ist sehr ressourcenaufwendig!
+options.renderDistance.tooltip.8=Werte über 16 funktionieren nur im Einzelspielermodus.
 
 options.ao.tooltip.1=Weiche Beleuchtung
-options.ao.tooltip.2=  AUS - keine weiche Beleuchtung (schnell)
-options.ao.tooltip.3=  Minimum - einfache weiche Beleuchtung (langsam)
-options.ao.tooltip.4=  Maximum - komplexe weiche Beleuchtung (am langsamsten)
+options.ao.tooltip.2=  Aus - Keine weiche Beleuchtung (schnell)
+options.ao.tooltip.3=  Minimum - Einfache weiche Beleuchtung (langsam)
+options.ao.tooltip.4=  Maximum - Komplexe weiche Beleuchtung (am langsamsten)
 
-options.framerateLimit.tooltip.1=Maximale Bildwiederholrate
-options.framerateLimit.tooltip.2=  V-Sync - auf Monitor-Bildwiederholrate beschränken (60, 30, 20)
-options.framerateLimit.tooltip.3=  5-255 - variabel
-options.framerateLimit.tooltip.4=  Unendlich - kein Limit (am schnellsten)
-options.framerateLimit.tooltip.5=Die Bildwiederholrate beschränkt die FPS, sogar wenn
-options.framerateLimit.tooltip.6=das Limit nicht erreicht ist.
+options.framerateLimit.tooltip.1=Maximale Bildrate
+options.framerateLimit.tooltip.2=  V-Sync - Auf Monitor-Bildrate begrenzen (60, 30, 20)
+options.framerateLimit.tooltip.3=  5-255 - Auf eingestellte Bildrate begrenzen
+options.framerateLimit.tooltip.4=  Unendlich - Keine Begrenzung (am schnellsten)
+options.framerateLimit.tooltip.5=Die Bildrate grenzt die FPS ein, sogar wenn
+options.framerateLimit.tooltip.6=die Begrenzung nicht erreicht ist.
 of.options.framerateLimit.vsync=V-Sync
 
-of.options.AO_LEVEL=Weiche Beleuchtungsstufen
-of.options.AO_LEVEL.tooltip.1=Weiche Beleuchtungsstufen
-of.options.AO_LEVEL.tooltip.2=  AUS - keine Schatten
-of.options.AO_LEVEL.tooltip.3=  50%% - helle Schatten
-of.options.AO_LEVEL.tooltip.4=  100%% - dunkle Schatten
+of.options.AO_LEVEL=Schattenhelligkeit
+of.options.AO_LEVEL.tooltip.1=Schattenhelligkeit
+of.options.AO_LEVEL.tooltip.2=  Aus - Keine Schatten
+of.options.AO_LEVEL.tooltip.3=  50%% - Helle Schatten
+of.options.AO_LEVEL.tooltip.4=  100%% - Dunkle Schatten
 
-options.viewBobbing.tooltip.1=Realistischere Bewegung
-options.viewBobbing.tooltip.2=Wenn Mipmaps verwendet werden, stelle es auf AUS für beste Ergebnisse.
+options.viewBobbing.tooltip.1=Gehbewegung
+options.viewBobbing.tooltip.2=Wenn Mipmaps verwendet werden, deaktiviere diese
+options.viewBobbing.tooltip.3=Einstellung für bessere Leitung.
 
 options.guiScale.tooltip.1=GUI-Größe
-options.guiScale.tooltip.2=Eine kleinere GUI ist eventuell schneller
+options.guiScale.tooltip.2=Ein kleineres GUI ist eventuell schneller.
 
 options.vbo.tooltip.1=Vertexbufferobjekte
-options.vbo.tooltip.2=Benutzt ein alternatives Rendering-Modell, das normalerweise
-options.vbo.tooltip.3=(5-10%%) schneller ist als das Standard-Rendering.
+options.vbo.tooltip.2=Benutzt ein alternatives Rendermodell, das normalerweise
+options.vbo.tooltip.3=schneller (5-10%%) als das Standard-Rendermodell ist.
 
 options.gamma.tooltip.1=Erhöht die Helligkeit dunkler Objekte
-options.gamma.tooltip.2=  AUS - Standardhelligkeit
-options.gamma.tooltip.3=  100%% - Maximale Helligkeit für dunkle Objekte
-options.gamma.tooltip.4=Diese Einstellungen ändern nicht die Helligkeit von 
-options.gamma.tooltip.5=ganz schwarzen Objekten
+options.gamma.tooltip.2=  Düster - Standardhelligkeit
+options.gamma.tooltip.3=  Hell - Maximale Helligkeit für dunkle Objekte
+options.gamma.tooltip.4=Diese Einstellungen ändern nicht die Helligkeit von ganz
+options.gamma.tooltip.5=schwarzen Objekten
 
-options.anaglyph.tooltip.1=3D-Anaglypheffekt
-options.anaglyph.tooltip.2=Aktiviert einen stereoskopischen 3D-Effekt durch benutzen
-options.anaglyph.tooltip.3=verschiedener Farben für jedes Auge
-options.anaglyph.tooltip.4=Benötigt eine Rot-Cyan-Brille für korrekte Sicht.
+options.anaglyph.tooltip.1=3D-Modus
+options.anaglyph.tooltip.2=Kann nur mit einer Rot-Cyan-Brille benutzt werden.
+options.anaglyph.tooltip.3=Aktiviert einen stereoskopischen 3D-Effekt durch
+options.anaglyph.tooltip.4=Verwenden unterschiedlicher Farben für jedes Auge.
 
-options.blockAlternatives.tooltip.1=Alternative Blöcke
-options.blockAlternatives.tooltip.2=Benutzt alternative Blockmodelle für ein paar Blöcke.
-options.blockAlternatives.tooltip.3=Kommt auf das ausgewählte Ressourcenpaket an.
+options.blockAlternatives.tooltip.1=Blockvarianten
+options.blockAlternatives.tooltip.2=Benutzt alternative Blockmodelle für einige Blöcke.
+options.blockAlternatives.tooltip.3=Hängt vom ausgewählten Ressourcenpaket ab.
 
 of.options.FOG_FANCY=Nebel
-of.options.FOG_FANCY.tooltip.1=Nebeltyp
+of.options.FOG_FANCY.tooltip.1=Nebel
 of.options.FOG_FANCY.tooltip.2=  Schnell - Schneller Nebel
 of.options.FOG_FANCY.tooltip.3=  Schön - Langsamer Nebel, sieht besser aus
-of.options.FOG_FANCY.tooltip.4=  AUS - Kein Nebel, am schnellsten
-of.options.FOG_FANCY.tooltip.5=Der schöne Nebel ist nur verfügbar, wenn er von der Grafikkarte
-of.options.FOG_FANCY.tooltip.6=unterstützt wird.
+of.options.FOG_FANCY.tooltip.4=  Aus - Kein Nebel, am schnellsten
+of.options.FOG_FANCY.tooltip.5=Der schöne Nebel ist nur verfügbar, wenn er von der
+of.options.FOG_FANCY.tooltip.6=Grafikkarte unterstützt wird.
 
 of.options.FOG_START=Nebelstart
 of.options.FOG_START.tooltip.1=Nebelstart
 of.options.FOG_START.tooltip.2=  0.2 - Der Nebel startet nahe beim Spieler
 of.options.FOG_START.tooltip.3=  0.8 - Der Nebel startet weit weg vom Spieler
-of.options.FOG_START.tooltip.4=Diese Option beeinflusst normalerweise nicht die Leistung.
+of.options.FOG_START.tooltip.4=Diese Einstellung beeinflusst normalerweise nicht die
+of.options.FOG_START.tooltip.5=Leistung.
 
 of.options.CHUNK_LOADING=Chunkladen
 of.options.CHUNK_LOADING.tooltip.1=Chunkladen
-of.options.CHUNK_LOADING.tooltip.2=  Standard - unstabile FPS, wenn Chunks geladen werden
-of.options.CHUNK_LOADING.tooltip.3=  Weich - stabile FPS
-of.options.CHUNK_LOADING.tooltip.4=  Multi-Kern - stabile FPS, 3x schnelleres Weltladen
-of.options.CHUNK_LOADING.tooltip.5=Weich und Multi-Kern entfernen Ruckler und
+of.options.CHUNK_LOADING.tooltip.2=  Standard - Instabile FPS, wenn Chunks geladen werden
+of.options.CHUNK_LOADING.tooltip.3=  Weich - Stabile FPS
+of.options.CHUNK_LOADING.tooltip.4=  Multi-Core - Stabile FPS, 3x schnelleres Weltladen
+of.options.CHUNK_LOADING.tooltip.5=Weich und Multi-Core entfernen Ruckler und
 of.options.CHUNK_LOADING.tooltip.6=Standbilder, welche durch Chunkladen verursacht werden.
-of.options.CHUNK_LOADING.tooltip.7=Multi-Kern kann das Weltladen 3x schneller machen und
+of.options.CHUNK_LOADING.tooltip.7=Multi-Core kann das Weltladen 3x schneller machen und
 of.options.CHUNK_LOADING.tooltip.8=die FPS erhöhen, indem es einen zweiten CPU-Kern benutzt.
 of.options.chunkLoading.smooth=Weich
-of.options.chunkLoading.multiCore=Multi-Kern
+of.options.chunkLoading.multiCore=Multi-Core
 
-of.options.shaders=Shader-Effekte...
+of.options.shaders=Shader-Effekte ...
 of.options.shadersTitle=Shader-Effekte
+
+of.options.shaders.packNone=Aus
+of.options.shaders.packDefault=(Interner Shader-Effekt)
 
 of.options.shaders.ANTIALIASING=Antialiasing
 of.options.shaders.NORMAL_MAP=Normale Karte
-of.options.shaders.SPECULAR_MAP=Spiegelkarte
+of.options.shaders.SPECULAR_MAP=Spiegelnde Karte
 of.options.shaders.RENDER_RES_MUL=Renderqualität
 of.options.shaders.SHADOW_RES_MUL=Schattenqualität
 of.options.shaders.HAND_DEPTH_MUL=Handtiefe
@@ -138,22 +145,27 @@ of.options.shaders.CLOUD_SHADOW=Wolkenschatten
 of.options.shaders.OLD_LIGHTING=Alte Beleuchtung
 of.options.shaders.SHADER_PACK=Shaderpaket
 
-of.options.quality=Qualität...
+of.options.shaders.shadersFolder=Shader-Effekt-Ordner
+of.options.shaders.shaderOptions=Shadereinstellung ...
+
+of.options.shaderOptionsTitle=Shader-Effekte
+
+of.options.quality=Qualität ...
 of.options.qualityTitle=Qualitätseinstellungen
 
-of.options.details=Details...
+of.options.details=Details ...
 of.options.detailsTitle=Detaileinstellungen
 
-of.options.performance=Leistung...
+of.options.performance=Leistung ...
 of.options.performanceTitle=Leistungseinstellungen
 
-of.options.animations=Animationen...
+of.options.animations=Animationen ...
 of.options.animationsTitle=Animationseinstellungen
 
-of.options.other=Sonstiges...
+of.options.other=Sonstiges ...
 of.options.otherTitle=Andere Einstellungen
 
-of.options.other.reset=Grafikeinstellungen zurücksetzen...
+of.options.other.reset=Grafikeinstellungen zurücksetzen ...
 
 of.shaders.profile=Profil
 
@@ -164,273 +176,283 @@ of.options.mipmap.linear=Linear
 of.options.mipmap.nearest=Am nächsten
 of.options.mipmap.trilinear=Trilinear
 
-options.mipmapLevels.tooltip.1=Visueller Effekt, der weit entfernte Objekte besser aussehen lässt
-options.mipmapLevels.tooltip.2=indem man die Texturdetails abweicht
-options.mipmapLevels.tooltip.3=  AUS - Keine Abweichung
-options.mipmapLevels.tooltip.4=  1 - Minimale Abweichung
-options.mipmapLevels.tooltip.5=  4 - Maximale Abweichung
-options.mipmapLevels.tooltip.6=Diese Option beeinflusst normalerweise nicht die Leistung.
+options.mipmapLevels.tooltip.1=Visueller Effekt, der weit entfernte Objekte besser aus-
+options.mipmapLevels.tooltip.2=sehen lässt, indem Texturdetails verringert werden
+options.mipmapLevels.tooltip.3=  Aus - Keine Verringerung von Details
+options.mipmapLevels.tooltip.4=  1 - Minimale Verringerung von Details
+options.mipmapLevels.tooltip.5=  4 - Maximale Verringerung von Details
+options.mipmapLevels.tooltip.6=Diese Einstellung beeinflusst normalerweise nicht die
+options.mipmapLevels.tooltip.7=Leistung.
 
 of.options.MIPMAP_TYPE=Mipmap-Typ
-of.options.MIPMAP_TYPE.tooltip.1=Visueller Effekt, der weit entfernte Objekte besser aussehen lässt
-of.options.MIPMAP_TYPE.tooltip.2=indem man die Texturdetails abweicht
-of.options.MIPMAP_TYPE.tooltip.3=  Am nächsten - Scharfe Abweichung (am schnellsten)
-of.options.MIPMAP_TYPE.tooltip.4=  Linear - Normale Abweichung
-of.options.MIPMAP_TYPE.tooltip.5=  Bilinear - Feine Abweichung
-of.options.MIPMAP_TYPE.tooltip.6=  Trilinear - Feinste Abweichung (am langsamsten)
+of.options.MIPMAP_TYPE.tooltip.1=Visueller Effekt, der weit entfernte Objekte besser aus-
+of.options.MIPMAP_TYPE.tooltip.2=sehen lässt, indem Texturdetails verringert werden
+of.options.MIPMAP_TYPE.tooltip.3=  Am nächsten - Grobe Verringerung (am schnellsten)
+of.options.MIPMAP_TYPE.tooltip.4=  Linear - Normale Verringerung
+of.options.MIPMAP_TYPE.tooltip.5=  Bilinear - Feine Verringerung
+of.options.MIPMAP_TYPE.tooltip.6=  Trilinear - Feinste Verringerung (am langsamsten)
 
 
 of.options.AA_LEVEL=Antialiasing
 of.options.AA_LEVEL.tooltip.1=Antialiasing
-of.options.AA_LEVEL.tooltip.2= AUS - (Standard) kein Antialiasing (schneller)
-of.options.AA_LEVEL.tooltip.3= 2-16 - antialiasierte Linien und Ecken (langsamer)
-of.options.AA_LEVEL.tooltip.4=Das Antialiasing weicht gezackte Linien ab und 
-of.options.AA_LEVEL.tooltip.5=verschärft Farbübergänge.
-of.options.AA_LEVEL.tooltip.6=Wenn aktiviert, sollte es im Wesentlichen die FPS erhöhen.
-of.options.AA_LEVEL.tooltip.7=Nicht alle Stufen werden von allen Grafikkarten unterstützt.
-of.options.AA_LEVEL.tooltip.8=Erst nach einem NEUSTART effektiv!
+of.options.AA_LEVEL.tooltip.2= Aus - (Standard) Kein Antialiasing (schneller)
+of.options.AA_LEVEL.tooltip.3= 2-16 - Antialiasierte Linien und Ecken (langsamer)
+of.options.AA_LEVEL.tooltip.4=Das Antialiasing weicht gezackte Linien ab und schärft
+of.options.AA_LEVEL.tooltip.5=Farbübergänge. Wenn aktiviert, sollte es im Wesentlichen
+of.options.AA_LEVEL.tooltip.6=die Bildrate erhöhen. Nicht alle Stufen werden von allen
+of.options.AA_LEVEL.tooltip.7=Grafikkarten unterstützt.
+of.options.AA_LEVEL.tooltip.8=Änderung wird erst nach einem Neustart effektiv!
 
 of.options.AF_LEVEL=Anisotropische Filterung
 of.options.AF_LEVEL.tooltip.1=Anisotropische Filterung
-of.options.AF_LEVEL.tooltip.2= AUS - (Standard) Standard Texturdetails (schneller)
-of.options.AF_LEVEL.tooltip.3= 2-16 - Feiner Details in mipmapped Texturen (langsamer)
-of.options.AF_LEVEL.tooltip.4=Die Anisotropische Filterung stellt Details in Mipmapped
-of.options.AF_LEVEL.tooltip.5=Texturen wieder her.
+of.options.AF_LEVEL.tooltip.2= Aus - (Standard) Standard-Texturdetails (schneller)
+of.options.AF_LEVEL.tooltip.3= 2-16 - Feinere Details in Texturen (langsamer)
+of.options.AF_LEVEL.tooltip.4=Die anisotropische Filterung stellt Details in Texturen,
+of.options.AF_LEVEL.tooltip.5=die durch Mipmap ihre Details verloren haben, wieder her.
 of.options.AF_LEVEL.tooltip.6=Wenn aktiviert, sollte es im Wesentlichen die FPS erhöhen.
 
 of.options.CLEAR_WATER=Klares Wasser
 of.options.CLEAR_WATER.tooltip.1=Klares Wasser
-of.options.CLEAR_WATER.tooltip.2=  AN - klares, transparentes Wasser
-of.options.CLEAR_WATER.tooltip.3=  AUS - normales Wasser
+of.options.CLEAR_WATER.tooltip.2=  An - Klares, transparentes Wasser
+of.options.CLEAR_WATER.tooltip.3=  Aus - Normales Wasser
 
-of.options.RANDOM_MOBS=Verschiedene Mobs
-of.options.RANDOM_MOBS.tooltip.1=Verschiedene Mobs
-of.options.RANDOM_MOBS.tooltip.2=  AUS - keine verschiedenen Mobs, schneller
-of.options.RANDOM_MOBS.tooltip.3=  AN - verschiedene Mobs, langsamer
-of.options.RANDOM_MOBS.tooltip.4=Verschiedene Mobs benutzt verschiedene Texturen für Mobs.
-of.options.RANDOM_MOBS.tooltip.5=Dies benötigt ein Ressourcenpaket mit mehreren Mobtexturen.
+of.options.RANDOM_MOBS=Kreaturvarianten
+of.options.RANDOM_MOBS.tooltip.1=Kreaturvarianten
+of.options.RANDOM_MOBS.tooltip.2=  Aus - Keine Kreaturvarianten, schneller
+of.options.RANDOM_MOBS.tooltip.3=  An - Keine Kreaturvarianten, langsamer
+of.options.RANDOM_MOBS.tooltip.4=Die gleichen Kreaturen können unterschiedliche Texturen
+of.options.RANDOM_MOBS.tooltip.5=haben. Dies benötigt ein Ressourcenpaket mit entspre-
+of.options.RANDOM_MOBS.tooltip.6=chenden Texturen.
 
 of.options.BETTER_GRASS=Besseres Gras
 of.options.BETTER_GRASS.tooltip.1=Besseres Gras
-of.options.BETTER_GRASS.tooltip.2=  AUS - Standard Grasseitentextur, am schnellsten
+of.options.BETTER_GRASS.tooltip.2=  Aus - Standard-Grasseitentextur, am schnellsten
 of.options.BETTER_GRASS.tooltip.3=  Schnell - Volle Grasseitentextur, langsamer
 of.options.BETTER_GRASS.tooltip.4=  Schön - Dynamische Grasseitentextur, am langsamsten
 
 of.options.BETTER_SNOW=Besserer Schnee
 of.options.BETTER_SNOW.tooltip.1=Besserer Schnee
-of.options.BETTER_SNOW.tooltip.2=  AUS - Normaler Schnee, schneller
-of.options.BETTER_SNOW.tooltip.3=  AN - Besserer Schnee, langsamer
-of.options.BETTER_SNOW.tooltip.4=Zeigt Schee unter transparenten Blöcken (Zaun, hohes Gras)
-of.options.BETTER_SNOW.tooltip.5=wenn sie an Schneeblöcken grenzen
+of.options.BETTER_SNOW.tooltip.2=  Aus - Normaler Schnee, schneller
+of.options.BETTER_SNOW.tooltip.3=  An - Besserer Schnee, langsamer
+of.options.BETTER_SNOW.tooltip.4=Setzt Schee unter transparente Blöcke (wie Zäune
+of.options.BETTER_SNOW.tooltip.5=oder hohes Gras), wenn sie an Schneeblöcke grenzen
 
-of.options.CUSTOM_FONTS=Eigene Schriftarten
-of.options.CUSTOM_FONTS.tooltip.1=Eigene Schriftarten
-of.options.CUSTOM_FONTS.tooltip.2=  AN - Benutzt verschiedene Schriftarten (Standard), langsamer
-of.options.CUSTOM_FONTS.tooltip.3=  AUS - Benutzt Standardschriftart, schneller
-of.options.CUSTOM_FONTS.tooltip.4=Die eigenen Schriftarten werden aus dem derzeitigen
-of.options.CUSTOM_FONTS.tooltip.5=Ressourcenpaket geladen
+of.options.CUSTOM_FONTS=Schriftartressourcen
+of.options.CUSTOM_FONTS.tooltip.1=Schriftarteressourcen
+of.options.CUSTOM_FONTS.tooltip.2=  AN - Ressourcenpaket-Schriftart (Standard), langsamer
+of.options.CUSTOM_FONTS.tooltip.3=  AUS - Standardschriftart, schneller
+of.options.CUSTOM_FONTS.tooltip.4=Die Schriftart wird aus den aktivierten Ressourcenpaketen
+of.options.CUSTOM_FONTS.tooltip.5=geladen
 
-of.options.CUSTOM_COLORS=Eigene Farben
-of.options.CUSTOM_COLORS.tooltip.1=Eigene Farben
-of.options.CUSTOM_COLORS.tooltip.2=  AN - Benutzt eigene Farben (Standard), langsamer
-of.options.CUSTOM_COLORS.tooltip.3=  AUS - Benutzt Standardfarben, schneller
-of.options.CUSTOM_COLORS.tooltip.4=Die eigenen Farben werden aus dem derzeitigen
-of.options.CUSTOM_COLORS.tooltip.5=Ressourcenpaket geladen
+of.options.CUSTOM_COLORS=Farbressourcen
+of.options.CUSTOM_COLORS.tooltip.1=Farbressourcen
+of.options.CUSTOM_COLORS.tooltip.2=  An - Ressourcenpaket-Farben (Standard), langsamer
+of.options.CUSTOM_COLORS.tooltip.3=  Aus - Standardfarben, schneller
+of.options.CUSTOM_COLORS.tooltip.4=Die Farben werden aus den aktivierten Ressourcenpaketen
+of.options.CUSTOM_COLORS.tooltip.5=geladen
 
 of.options.SWAMP_COLORS=Sumpffarben
 of.options.SWAMP_COLORS.tooltip.1=Sumpffarben
-of.options.SWAMP_COLORS.tooltip.2=  AN - Benutzt Sumpffarben (Standard), langsamer
-of.options.SWAMP_COLORS.tooltip.3=  AUS - Benutzt keine Sumpffarben, schneller
-of.options.SWAMP_COLORS.tooltip.4=Die Sumpffarben betreffen Gras, Laub, Ranken und Wasser.
+of.options.SWAMP_COLORS.tooltip.2=  An - Färbt den Sumpf dunkler (Standard), langsamer
+of.options.SWAMP_COLORS.tooltip.3=  Aus - Färbt den Sumpf in normalen Farben, schneller
+of.options.SWAMP_COLORS.tooltip.4=Die Sumpffarben betreffen Gras, Laub, Ranken und
+of.options.SWAMP_COLORS.tooltip.5=Wasser.
 
-of.options.SMOOTH_BIOMES=Weiche Biome
-of.options.SMOOTH_BIOMES.tooltip.1=Weiche Biome
-of.options.SMOOTH_BIOMES.tooltip.2=  AN - Abweichen der Biomgrenzen (Standard), langsamer
-of.options.SMOOTH_BIOMES.tooltip.3=  AUS - Kein Abweichen der Biomgrenzen, schneller
-of.options.SMOOTH_BIOMES.tooltip.4=Das Abweichen der Biomgrenzen wird durch Probennahme und
-of.options.SMOOTH_BIOMES.tooltip.5=Durchschnittsrechnung der Farben der umliegenden Blöcke berechnet.
-of.options.SMOOTH_BIOMES.tooltip.6=Betroffen sind Gras, Laub, Ranken und Wasser.
+of.options.SMOOTH_BIOMES=Biomübergänge
+of.options.SMOOTH_BIOMES.tooltip.1=Biomübergänge
+of.options.SMOOTH_BIOMES.tooltip.2=  An - Farbübergänge an Biomgrenzen (Standard), langsamer
+of.options.SMOOTH_BIOMES.tooltip.3=  Aus - Keine Farbübergänge an Biomgrenzen, schneller
+of.options.SMOOTH_BIOMES.tooltip.4=Die Farbübergänge werden durch Probennahme und
+of.options.SMOOTH_BIOMES.tooltip.5=Durchschnittsberechnung der Farben der umliegenden
+of.options.SMOOTH_BIOMES.tooltip.6=Blöcke berechnet. Betroffen sind Gras, Laub, Ranken und
+of.options.SMOOTH_BIOMES.tooltip.7=Wasser.
 
 of.options.CONNECTED_TEXTURES=Verbundene Texturen
 of.options.CONNECTED_TEXTURES.tooltip.1=Verbundene Texturen
-of.options.CONNECTED_TEXTURES.tooltip.2=  AUS - Keine verbundenen Texturen (Standard)
+of.options.CONNECTED_TEXTURES.tooltip.2=  Aus - Keine verbundenen Texturen (Standard)
 of.options.CONNECTED_TEXTURES.tooltip.3=  Schnell - Schnelle verbundene Texturen
 of.options.CONNECTED_TEXTURES.tooltip.4=  Schöne - Schöne verbundene Texturen
 of.options.CONNECTED_TEXTURES.tooltip.5=Verbundene Texturen verbinden die Texturen von Glas,
 of.options.CONNECTED_TEXTURES.tooltip.6=Sandstein und Bücherregalen, wenn sie nebeneinander
-of.options.CONNECTED_TEXTURES.tooltip.7=platziert werden. Die verbundenen Texturen werden aus dem
-of.options.CONNECTED_TEXTURES.tooltip.8=derzeitigen Ressourcenpaket geladen.
+of.options.CONNECTED_TEXTURES.tooltip.7=platziert werden. Die verbundenen Texturen werden aus
+of.options.CONNECTED_TEXTURES.tooltip.8=den aktivierten Ressourcenpaketen geladen.
 
 of.options.NATURAL_TEXTURES=Natürliche Texturen
 of.options.NATURAL_TEXTURES.tooltip.1=Natürliche Texturen
-of.options.NATURAL_TEXTURES.tooltip.2=  AUS - Keine natürlichen Texturen (Standard)
-of.options.NATURAL_TEXTURES.tooltip.3=  AN - Benutzt natürliche Texturen
-of.options.NATURAL_TEXTURES.tooltip.4=Natürliche Texturen entfernen die tabellenartige 
-of.options.NATURAL_TEXTURES.tooltip.5=Anordnung, erzeugt durch Platzieren von gleichen Blöcken.
-of.options.NATURAL_TEXTURES.tooltip.6=Dies benutzt gedrehte und umgekehrte Varianten der Standard-
+of.options.NATURAL_TEXTURES.tooltip.2=  Aus - Keine natürlichen Texturen (Standard)
+of.options.NATURAL_TEXTURES.tooltip.3=  An - Benutzt natürliche Texturen
+of.options.NATURAL_TEXTURES.tooltip.4=Natürliche Texturen entfernen die rasterartige Anordnung,
+of.options.NATURAL_TEXTURES.tooltip.5=erzeugt durch Platzieren von gleichen Blöcken. Dies be-
+of.options.NATURAL_TEXTURES.tooltip.6=nutzt gedrehte und umgekehrte Varianten der Standard-
 of.options.NATURAL_TEXTURES.tooltip.7=Blocktextur. Die Einstellungen für die natürlichen Texturen
-of.options.NATURAL_TEXTURES.tooltip.8=werden aus dem derzeitigen Ressourcenpaket geladen.
+of.options.NATURAL_TEXTURES.tooltip.8=werden aus den aktivierten Ressourcenpaketen geladen.
 
-of.options.CUSTOM_SKY=Eigener Himmel
-of.options.CUSTOM_SKY.tooltip.1=Eigener Himmel
-of.options.CUSTOM_SKY.tooltip.2=  AN - Eigene Himmeltexturen (Standard), langsam
+of.options.CUSTOM_SKY=Himmeltexturen
+of.options.CUSTOM_SKY.tooltip.1=Himmeltexturen
+of.options.CUSTOM_SKY.tooltip.2=  An - Ressourcenpaket-Himmeltexturen (Standard), langsam
 of.options.CUSTOM_SKY.tooltip.3=  AUS - Standardhimmel, schneller
-of.options.CUSTOM_SKY.tooltip.4=Die eigenen Himmeltexturen werden aus dem derzeitigen
-of.options.CUSTOM_SKY.tooltip.5=Ressourcenpaket geladen.
+of.options.CUSTOM_SKY.tooltip.4=Die Himmeltexturen werden aus den aktivierten
+of.options.CUSTOM_SKY.tooltip.5=Ressourcenpaketen geladen.
 
-of.options.CUSTOM_ITEMS=Eigene Items
-of.options.CUSTOM_ITEMS.tooltip.1=Eigene Itemexturen
-of.options.CUSTOM_ITEMS.tooltip.2=  AN - Eigene Itemtexturen (Standard), langsam
-of.options.CUSTOM_ITEMS.tooltip.3=  AUS - Standard Itemtexturen, schneller
-of.options.CUSTOM_ITEMS.tooltip.4=Die eigenen Itemtexturen werden aus dem derzeitigen
-of.options.CUSTOM_ITEMS.tooltip.5=Ressourcenpaket geladen.
+of.options.CUSTOM_ITEMS=Gegenstandstexturen
+of.options.CUSTOM_ITEMS.tooltip.1=Gegenstandstexturen
+of.options.CUSTOM_ITEMS.tooltip.2=  An - Ressourcenpaket-G.texturen (Standard), langsam
+of.options.CUSTOM_ITEMS.tooltip.3=  Aus - Standard-Gegenstandstexturen, schneller
+of.options.CUSTOM_ITEMS.tooltip.4=Die Gegenstandstexturen werden aus den aktivierten
+of.options.CUSTOM_ITEMS.tooltip.5=Ressourcenpaketen geladen.
 
 # Details
 
 of.options.CLOUDS=Wolken
 of.options.CLOUDS.tooltip.1=Wolken
-of.options.CLOUDS.tooltip.2=  Standard - Wie Grafikeinstellungen
-of.options.CLOUDS.tooltip.3=  Schnell - schlechtere Qualität, schneller
+of.options.CLOUDS.tooltip.2=  Standard - Wie Grafikmodus
+of.options.CLOUDS.tooltip.3=  Schnell - Schlechtere Qualität, schneller
 of.options.CLOUDS.tooltip.4=  Schön - Höhere Qualität, langsamer
-of.options.CLOUDS.tooltip.5=  AUS - Keine Wolken, am schnellsten
-of.options.CLOUDS.tooltip.6=Schnelle Wolken werden 2D gerendert.
-of.options.CLOUDS.tooltip.7=Schöne Wolken werden 3D gerendert.
+of.options.CLOUDS.tooltip.5=  Aus - Keine Wolken, am schnellsten
+of.options.CLOUDS.tooltip.6=Schnelle Wolken werden zweidimensional dargestellt.
+of.options.CLOUDS.tooltip.7=Schöne Wolken werden dreidimensional dargestellt.
 
 of.options.CLOUD_HEIGHT=Wolkenhöhe
 of.options.CLOUD_HEIGHT.tooltip.1=Wolkenhöhe
-of.options.CLOUD_HEIGHT.tooltip.2=  AUS - Standardhöhe
-of.options.CLOUD_HEIGHT.tooltip.3=  100%% - Über dem Welthöhenlimit
+of.options.CLOUD_HEIGHT.tooltip.2=  Aus - Standardhöhe
+of.options.CLOUD_HEIGHT.tooltip.3=  100%% - Über der maximalen Welthöhe
 
 of.options.TREES=Bäume
 of.options.TREES.tooltip.1=Bäume
-of.options.TREES.tooltip.2=  Standard - Wie Grafikeinstellungen
+of.options.TREES.tooltip.2=  Standard - Wie Grafikmodus
 of.options.TREES.tooltip.3=  Schnell - Schlechtere Qualität, schneller
 of.options.TREES.tooltip.4=  Fein - Hohe Qualität, schnell
 of.options.TREES.tooltip.5=  Schön - Höchste Qualität, langsamer
-of.options.TREES.tooltip.6=Schnelle Bäume haben undurchsichtige Blätter.
-of.options.TREES.tooltip.7=Schöne Bäume haben durchsichtige Blätter.
+of.options.TREES.tooltip.6=Schnelle Bäume haben solide Blätter.
+of.options.TREES.tooltip.7=Schöne Bäume haben teilweise transparente Blätter.
 
 of.options.RAIN=Regen & Schnee
 of.options.RAIN.tooltip.1=Regen & Schnee
-of.options.RAIN.tooltip.2=  Standard - Wie Grafikeinstellungen
-of.options.RAIN.tooltip.3=  Schnell - leichter Regen/Schnee, schneller
+of.options.RAIN.tooltip.2=  Standard - Wie Grafikmodus
+of.options.RAIN.tooltip.3=  Schnell - Leichter Regen/Schnee, schneller
 of.options.RAIN.tooltip.4=  Schön - Starker Regen/Schnee, langsamer
-of.options.RAIN.tooltip.5=  AUS - Kein Regen/Schnee, am schnellsten
-of.options.RAIN.tooltip.6=Wenn Regen AUS ist, sind die Platscher und Sounds
-of.options.RAIN.tooltip.7=trotzdem noch aktiv.
+of.options.RAIN.tooltip.5=  Aus - Kein Regen/Schnee, am schnellsten
+of.options.RAIN.tooltip.6=Wenn diese Einstellung deaktiviert ist, sind die Regen-
+of.options.RAIN.tooltip.7=geräusche und -partikel dennoch zu hören bzw. zu sehen.
 
 of.options.SKY=Himmel
 of.options.SKY.tooltip.1=Himmel
-of.options.SKY.tooltip.2=  AN - Himmel ist sichtbar, langsamer
-of.options.SKY.tooltip.3=  AUS  - Himmel ist nicht sichtbar, schneller
-of.options.SKY.tooltip.4=Wenn Himmel AUS ist, sind der Mond und die Sonne trotzdem noch sichtbar.
+of.options.SKY.tooltip.2=  An - Himmel ist sichtbar, langsamer
+of.options.SKY.tooltip.3=  Aus - Himmel ist nicht sichtbar, schneller
+of.options.SKY.tooltip.4=Wenn dies deaktiviert ist, sind Mond und Sonne dennoch
+of.options.SKY.tooltip.5=sichtbar.
 
 of.options.STARS=Sterne
 of.options.STARS.tooltip.1=Sterne
-of.options.STARS.tooltip.2=  AN - Sterne sind sichtbar, langsamer
-of.options.STARS.tooltip.3=  AUS  - Sterne ist nicht sichtbar, schneller
+of.options.STARS.tooltip.2=  An - Sterne sind sichtbar, langsamer
+of.options.STARS.tooltip.3=  Aus - Sterne ist nicht sichtbar, schneller
 
 of.options.SUN_MOON=Sonne & Mond
 of.options.SUN_MOON.tooltip.1=Sonne & Mond
-of.options.SUN_MOON.tooltip.2=  AN - Sonne und Mond sind sichtbar (Standard)
-of.options.SUN_MOON.tooltip.3=  AUS  - Sonne und Mond sind nicht sichtbar (schneller)
+of.options.SUN_MOON.tooltip.2=  An - Sonne und Mond sind sichtbar (Standard)
+of.options.SUN_MOON.tooltip.3=  Aus - Sonne und Mond sind nicht sichtbar (schneller)
 
-of.options.SHOW_CAPES=Zeige Umhänge
-of.options.SHOW_CAPES.tooltip.1=Zeige Umhänge
-of.options.SHOW_CAPES.tooltip.2=  AN - Zeige Umhänge (Standard)
-of.options.SHOW_CAPES.tooltip.3=  AUS - Zeige keine Umhänge
+of.options.SHOW_CAPES=Umhänge
+of.options.SHOW_CAPES.tooltip.1=Umhänge
+of.options.SHOW_CAPES.tooltip.2=  An - Umhänge werden dargestellt (Standard)
+of.options.SHOW_CAPES.tooltip.3=  Aus - Umhänge werden nicht dargestellt
 
-of.options.TRANSLUCENT_BLOCKS=Dursichtige Blöcke
-of.options.TRANSLUCENT_BLOCKS.tooltip.1=Dursichtige Blöcke
+of.options.TRANSLUCENT_BLOCKS=Blocktransparenz
+of.options.TRANSLUCENT_BLOCKS.tooltip.1=Blocktransparenz
 of.options.TRANSLUCENT_BLOCKS.tooltip.2=  Schön - Korrekte Farbmischung (Standard)
 of.options.TRANSLUCENT_BLOCKS.tooltip.3=  Schnell - Schnelle Farbmischung (schnell)
-of.options.TRANSLUCENT_BLOCKS.tooltip.4=Kontrolliert die Farbmischung von durchsichtigen Blöcken
-of.options.TRANSLUCENT_BLOCKS.tooltip.5=mit verschiedenen Farben (Gefärbtes Glas, Wasser, Eis)
-of.options.TRANSLUCENT_BLOCKS.tooltip.6=wenn sie hintereinander mit Luft dazwischen platziert werden.
+of.options.TRANSLUCENT_BLOCKS.tooltip.4=Kontrolliert die Farbmischung von transparenten Blöcken
+of.options.TRANSLUCENT_BLOCKS.tooltip.5=mit verschiedenen Farben (Gefärbtes Glas, Wasser, Eis),
+of.options.TRANSLUCENT_BLOCKS.tooltip.6=wenn sie hintereinander mit Luft dazwischen platziert
+of.options.TRANSLUCENT_BLOCKS.tooltip.7=werden.
 
-of.options.HELD_ITEM_TOOLTIPS=Itemnamen über Hotbar
-of.options.HELD_ITEM_TOOLTIPS.tooltip.1=Itemnamen über Hotbar
-of.options.HELD_ITEM_TOOLTIPS.tooltip.2=  AN - Zeige Itemnamen für derzeitige Items (Standard)
-of.options.HELD_ITEM_TOOLTIPS.tooltip.3=  AUS - Zeige keine Itemnamen für derzeitige Items
+of.options.HELD_ITEM_TOOLTIPS=Gegenstandsbeschr.
+of.options.HELD_ITEM_TOOLTIPS.tooltip.1=Gegenstandsbeschreibung
+of.options.HELD_ITEM_TOOLTIPS.tooltip.2=  An - Zeige Gegenstandsbeschreibung (Standard)
+of.options.HELD_ITEM_TOOLTIPS.tooltip.3=  Aus - Zeige keine Gegenstandsbeschreibung
+of.options.HELD_ITEM_TOOLTIPS.tooltip.4=Wird über der Schnellzugriffsleiste angezeigt.
 
-of.options.DROPPED_ITEMS=Liegende Items
-of.options.DROPPED_ITEMS.tooltip.1=Liegende Items
-of.options.DROPPED_ITEMS.tooltip.2=  Standard - Wie Grafikeinstellungen
-of.options.DROPPED_ITEMS.tooltip.3=  Schnell - 2D-Animation, schneller
-of.options.DROPPED_ITEMS.tooltip.4=  Schön - 3D-Animation, langsamer
+of.options.DROPPED_ITEMS=Gegenstände
+of.options.DROPPED_ITEMS.tooltip.1=Liegende Gegenstände
+of.options.DROPPED_ITEMS.tooltip.2=  Standard - Wie Grafikmodus
+of.options.DROPPED_ITEMS.tooltip.3=  Schnell - Zweidimensionale Animation, schneller
+of.options.DROPPED_ITEMS.tooltip.4=  Schön - Dreidimensionale Animation, langsamer
 
 options.entityShadows.tooltip.1=Objektschatten
-options.entityShadows.tooltip.2=  AN - Zeige Objektschatten
-options.entityShadows.tooltip.3=  AUS - Zeige keine Objektschatten
+options.entityShadows.tooltip.2=  An - Zeige Objektschatten
+options.entityShadows.tooltip.3=  Aus - Zeige keine Objektschatten
 
 of.options.VIGNETTE=Vignette
-of.options.VIGNETTE.tooltip.1=Visueller Effekt, der die Bildschirmecken schwärzt
-of.options.VIGNETTE.tooltip.2=  Standard - Wie Grafikeinstellungen (Standard)
+of.options.VIGNETTE.tooltip.1=Visueller Effekt, der die Bildschirmecken abdunkelt
+of.options.VIGNETTE.tooltip.2=  Standard - Wie Grafikmodus (Standard)
 of.options.VIGNETTE.tooltip.3=  Schnell - Vignette deaktiviert (schneller)
 of.options.VIGNETTE.tooltip.4=  Schön - Vignette aktiviert (langsamer)
-of.options.VIGNETTE.tooltip.5=Die Vignette kann einen extremen Effekt auf die FPS haben,
+of.options.VIGNETTE.tooltip.5=Die Vignette kann sich extrem auf die Leistung auswirken,
 of.options.VIGNETTE.tooltip.6=besonders im Vollbildschirmmodus.
-of.options.VIGNETTE.tooltip.7=Der Vignetteneffekt ist freiwillig und kann sicher
+of.options.VIGNETTE.tooltip.7=Der Vignetteneffekt ist fast unmerklich und kann sicher
 of.options.VIGNETTE.tooltip.8=deaktiviert werden.
 
 # Performance
 
-of.options.SMOOTH_FPS=Weiche FPS
-of.options.SMOOTH_FPS.tooltip.1=Stabilisiert die FPS, indem die Grafiktreiberpuffer genutzt werden
-of.options.SMOOTH_FPS.tooltip.2=  AUS - Keine Stabilisierung, FPS könnten schwanken
-of.options.SMOOTH_FPS.tooltip.3=  AN - FPS-Stabilisierung
-of.options.SMOOTH_FPS.tooltip.4=Diese Option ist Grafikkartentreiberabhängig und sein Effekt
-of.options.SMOOTH_FPS.tooltip.5=ist nicht immer spürbar.
+of.options.SMOOTH_FPS=Stabile Bildrate
+of.options.SMOOTH_FPS.tooltip.1=Stabilisiert Bildrate, indem Grafiktreiberpuffer genutzt werden
+of.options.SMOOTH_FPS.tooltip.2=  Aus - Keine Stabilisierung, Bildrate könnte schwanken
+of.options.SMOOTH_FPS.tooltip.3=  Am - Stabilisierung der Bildrate
+of.options.SMOOTH_FPS.tooltip.4=Diese Einstellung ist abhängig vom Grafikkartentreiber.
+of.options.SMOOTH_FPS.tooltip.5=Eine Wirkung ist nicht immer spürbar.
 
-of.options.SMOOTH_WORLD=Weiche Welt
-of.options.SMOOTH_WORLD.tooltip.1=Entfernt Laggspitzen, verursacht durch den internen Server.
-of.options.SMOOTH_WORLD.tooltip.2=  AUS - Keine Stabilisierung, FPS könnten schwanken
-of.options.SMOOTH_WORLD.tooltip.3=  AN - FPS-Stabilisierung
-of.options.SMOOTH_WORLD.tooltip.4=Stabilisiert die FPS, indem der interne Serverladevorgang aufgeteilt wird.
-of.options.SMOOTH_WORLD.tooltip.5=Nur für lokale Welten effektiv (Einzelspieler).
+of.options.SMOOTH_WORLD=Weltstabilisierung
+of.options.SMOOTH_WORLD.tooltip.1=Entfernt durch den internen Server verursache starke Lags
+of.options.SMOOTH_WORLD.tooltip.2=  Aus - Keine Stabilisierung, Bildrate könnte schwanken
+of.options.SMOOTH_WORLD.tooltip.3=  An - Weltstabilisierung aktiviert
+of.options.SMOOTH_WORLD.tooltip.4=Stabilisiert die Bildrate, indem der interne Serverlade-
+of.options.SMOOTH_WORLD.tooltip.5=vorgang aufgeteilt wird.
+of.options.SMOOTH_WORLD.tooltip=6=Funktioniert nur im Einzelspielermodus.
 
 of.options.FAST_RENDER=Schnelles Rendern
 of.options.FAST_RENDER.tooltip.1=Schnelles Rendern
-of.options.FAST_RENDER.tooltip.2= AUS - Standard-Rendern (Standard)
-of.options.FAST_RENDER.tooltip.3= AN - Optimiertes Rendern (schneller)
-of.options.FAST_RENDER.tooltip.4=Benutzt optimierte Renderalgorithmen, die das Laden der GPU
-of.options.FAST_RENDER.tooltip.5=verkleinern und erheblich die FPS steigern.
+of.options.FAST_RENDER.tooltip.2=  Aus - Standard-Rendern (Standard)
+of.options.FAST_RENDER.tooltip.3=  An - Optimiertes Rendern (schneller)
+of.options.FAST_RENDER.tooltip.4=Benutzt optimierte Renderalgorithmen, die das Laden der
+of.options.FAST_RENDER.tooltip.5=GPU verkleinern und die Leistung erheblich steigern.
 
 of.options.FAST_MATH=Schnelle Mathematik
 of.options.FAST_MATH.tooltip.1=Schnelle Mathematik
-of.options.FAST_MATH.tooltip.2= AUS - Standard-Mathematik (Standard)
-of.options.FAST_MATH.tooltip.3= AN - Schnellere Mathematik
-of.options.FAST_MATH.tooltip.4=Benutzt optimierte sin()- und cos()-Funktionen, die
-of.options.FAST_MATH.tooltip.5=den CPU-Zwischenspeicher besser nutzen und die FPS steigern.
+of.options.FAST_MATH.tooltip.2=  Aus - Standard-Mathematik (Standard)
+of.options.FAST_MATH.tooltip.3=  An - Schnellere Mathematik
+of.options.FAST_MATH.tooltip.4=Benutzt optimierte Sinus- und Kosinusfunktionen, die den
+of.options.FAST_MATH.tooltip.5=CPU-Zwischenspeicher besser nutzen und die Leistung
+of.options.FAST_MATH.tooltip.6=steigern.
 
 of.options.CHUNK_UPDATES=Chunk-Aktualisierungen
 of.options.CHUNK_UPDATES.tooltip.1=Chunk-Aktualisierungen
-of.options.CHUNK_UPDATES.tooltip.2= 1 - Langsameres Weltladen, höhere FPS (Standard)
-of.options.CHUNK_UPDATES.tooltip.3= 3 - Schnelleres Weltladen, niedrigere FPS
-of.options.CHUNK_UPDATES.tooltip.4= 5 - Schnellstes Weltladen, niedrigste FPS-Rate
-of.options.CHUNK_UPDATES.tooltip.5=Zahl an Chunk Updates pro gerendertes Bild,
-of.options.CHUNK_UPDATES.tooltip.6=höhere Werte könnten die Bildwiederholrate destabilisieren.
+of.options.CHUNK_UPDATES.tooltip.2=  1 - Langsameres Weltladen, höhere Bildrate (Standard)
+of.options.CHUNK_UPDATES.tooltip.3=  3 - Schnelleres Weltladen, niedrigere Bildrate
+of.options.CHUNK_UPDATES.tooltip.4=  5 - Schnellstes Weltladen, niedrigste Bildrate
+of.options.CHUNK_UPDATES.tooltip.5=Zahl an Chunk-Aktualisierungen pro gerendertem Bild.
+of.options.CHUNK_UPDATES.tooltip.6=Höhere Werte könnten die Bildrate destabilisieren.
 
-of.options.CHUNK_UPDATES_DYNAMIC=Dynamische Aktualisierungen
+of.options.CHUNK_UPDATES_DYNAMIC=Dyn. Aktualisierungen
 of.options.CHUNK_UPDATES_DYNAMIC.tooltip.1=Dynamische Chunk-Aktualisierungen
-of.options.CHUNK_UPDATES_DYNAMIC.tooltip.2= AUS - (Standard) Standard Chunk-Aktualisierungen pro Bild
-of.options.CHUNK_UPDATES_DYNAMIC.tooltip.3= AN - Mehr Aktualisierungen, während der Spieler still steht
-of.options.CHUNK_UPDATES_DYNAMIC.tooltip.4=Dynamische Aktualisierungen fordern mehr Chunk Aktualisierungen während
-of.options.CHUNK_UPDATES_DYNAMIC.tooltip.5=der Spieler still steht, um die Welt schneller zu laden.
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.2=  Aus - (Standard) Normale Chunk-Aktualisierungen
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.3=  An - Mehr Chunk-Aktualisierungen
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.4=Wenn diese Einstellung aktiviert ist, werden mehr Chunk-
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.5=Aktualisierungen ausgeführt, während der Spieler still
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.6=steht, um die Welt schneller zu laden.
 
 of.options.LAZY_CHUNK_LOADING=Träges Chunkladen
 of.options.LAZY_CHUNK_LOADING.tooltip.1=Träges Chunkladen
-of.options.LAZY_CHUNK_LOADING.tooltip.2= AUS - Standard Server-Chunkladen
-of.options.LAZY_CHUNK_LOADING.tooltip.3= AN - Träges Server-Chunkladen (weicher)
-of.options.LAZY_CHUNK_LOADING.tooltip.4=Server-Chunkladen wird flüssiger, indem
-of.options.LAZY_CHUNK_LOADING.tooltip.5=die Chunks über ein paar Ticks hinweg geladen werden.
-of.options.LAZY_CHUNK_LOADING.tooltip.6=Stelle es auf AUS, wenn Teile der Welt nicht korrekt geladen werden.
-of.options.LAZY_CHUNK_LOADING.tooltip.7=Nur für lokale Welten und Ein-Kern-CPUs effektiv.
+of.options.LAZY_CHUNK_LOADING.tooltip.2=  Aus - Standard-Server-Chunkladen
+of.options.LAZY_CHUNK_LOADING.tooltip.3=  An - Träges Server-Chunkladen (flüssiger)
+of.options.LAZY_CHUNK_LOADING.tooltip.4=Server-Chunkladen wird flüssiger, indem die Chunks über
+of.options.LAZY_CHUNK_LOADING.tooltip.5=ein paar Ticks hinweg geladen werden. Deaktiviere dies,
+of.options.LAZY_CHUNK_LOADING.tooltip.6=wenn Teile der Welt nicht korrekt geladen werden.
+of.options.LAZY_CHUNK_LOADING.tooltip.7=Nur für Einzelspielermodus und Ein-Kern-CPUs effektiv.
 
 # Animations
 
-of.options.animation.allOn=Alle AN
-of.options.animation.allOff=Alle AUS
+of.options.animation.allOn=Alle an
+of.options.animation.allOff=Alle aus
 of.options.animation.dynamic=Dynamisch
 
 of.options.ANIMATED_WATER=Animiertes Wasser
@@ -441,12 +463,12 @@ of.options.ANIMATED_REDSTONE=Animiertes Redstone
 of.options.ANIMATED_EXPLOSION=Animierte Explosion
 of.options.ANIMATED_FLAME=Animierte Flammen
 of.options.ANIMATED_SMOKE=Animierter Rauch
-of.options.VOID_PARTICLES=Leerenpartikel
+of.options.VOID_PARTICLES=Leerepartikel
 of.options.WATER_PARTICLES=Wasserpartikel
 of.options.RAIN_SPLASH=Regengeplätscher
 of.options.PORTAL_PARTICLES=Portalpartikel
 of.options.POTION_PARTICLES=Trankpartikel
-of.options.DRIPPING_WATER_LAVA=Tropfendes Wasser/Lava
+of.options.DRIPPING_WATER_LAVA=Wasser- & Lavatropfen
 of.options.ANIMATED_TERRAIN=Animiertes Gelände
 of.options.ANIMATED_TEXTURES=Animierte Texturen
 of.options.FIREWORK_PARTICLES=Feuerwerkpartikel
@@ -457,56 +479,58 @@ of.options.LAGOMETER=Lagometer
 of.options.LAGOMETER.tooltip.1=Zeigt das Lagometer auf dem Debugbildschirm (F3).
 of.options.LAGOMETER.tooltip.2=* Orange - Speichermüllsammlung
 of.options.LAGOMETER.tooltip.3=* Cyan - Tick
-of.options.LAGOMETER.tooltip.4=* Blau - Geplante Ausführbare Dateien
-of.options.LAGOMETER.tooltip.5=* Lila - Chunkhochladen
+of.options.LAGOMETER.tooltip.4=* Blau - Geplante Ausführungen
+of.options.LAGOMETER.tooltip.5=* Lila - Chunks hochladen
 of.options.LAGOMETER.tooltip.6=* Rot - Chunkaktualisierungen
 of.options.LAGOMETER.tooltip.7=* Gelb - Sichtbarkeitstest
-of.options.LAGOMETER.tooltip.8=* Grün - Rendergelände
+of.options.LAGOMETER.tooltip.8=* Grün - Gelände rendern
 
-of.options.PROFILER=Debugprofiler
-of.options.PROFILER.tooltip.1=Debugprofiler
-of.options.PROFILER.tooltip.2=  AN - Debugprofiler ist aktiv, langsamer
-of.options.PROFILER.tooltip.3=  AUS - Debugprofiler ist nicht aktiv, schneller
-of.options.PROFILER.tooltip.4=Der Debugprofiler sammelt und zeigt Debuginformationen
-of.options.PROFILER.tooltip.5=wenn der Debugbildschirm geöffnet ist (F3)
+of.options.PROFILER=Debug-Diagramm
+of.options.PROFILER.tooltip.1=Debug-Diagramm
+of.options.PROFILER.tooltip.2=  An - Debug-Diagramm ist aktiviert, langsamer
+of.options.PROFILER.tooltip.3=  Aus - Debug-Diagramm ist nicht aktiviert, schneller
+of.options.PROFILER.tooltip.4=Das Debug-Diagramm sammelt und stellt Debuginforma-
+of.options.PROFILER.tooltip.5=tionen dar, wenn der Debugbildschirm geöffnet ist (F3).
 
 of.options.WEATHER=Wetter
 of.options.WEATHER.tooltip.1=Wetter
-of.options.WEATHER.tooltip.2=  AN - Wetter ist aktiv, langsamer
-of.options.WEATHER.tooltip.3=  AUS - Wetter ist nicht aktiv, schneller
+of.options.WEATHER.tooltip.2=  An - Wetter ist aktiv, langsamer
+of.options.WEATHER.tooltip.3=  Aus - Wetter ist nicht aktiv, schneller
 of.options.WEATHER.tooltip.4=Das Wetter kontrolliert Regen, Schnee und Gewitter.
-of.options.WEATHER.tooltip.5=Wetterkontrolle ist nur in lokalen Welten möglich.
+of.options.WEATHER.tooltip.5=Wetterkontrolle ist nur im Einzelspielermodus möglich.
 
 of.options.time.dayOnly=Nur Tag
 of.options.time.nightOnly=Nur Nacht
 
 of.options.TIME=Zeit
 of.options.TIME.tooltip.1=Zeit
-of.options.TIME.tooltip.2= Standard - Normaler Tag/Nacht-Zyklus
+of.options.TIME.tooltip.2= Standard - Normaler Tag-Nacht-Zyklus
 of.options.TIME.tooltip.3= Nur Tag - Nur Tag
 of.options.TIME.tooltip.4= Nur Nacht - Nur Nacht
-of.options.TIME.tooltip.5=Die Zeiteinstellung ist nur im KREATIV-Modus und
-of.options.TIME.tooltip.6=in lokalen Welten effektiv.
+of.options.TIME.tooltip.5=Diese Einstellung ist nur im Kreativmodus und
+of.options.TIME.tooltip.6=im Einzelspielermodus wirksam.
 
 options.fullscreen.tooltip.1=Vollbildschirm
-options.fullscreen.tooltip.2=  AN - Benutze Vollbildschirmmodus
-options.fullscreen.tooltip.3=  AUS - Benutze Fenstermodus
-options.fullscreen.tooltip.4=Der Vollbildschirmmodus könnte schneller oder langsamer sein als
-options.fullscreen.tooltip.5=der Fenstermodus, kommt auf die Grafikkarte an.
+options.fullscreen.tooltip.2=  An - Benutze Vollbildschirmmodus
+options.fullscreen.tooltip.3=  Aus - Benutze Fenstermodus
+options.fullscreen.tooltip.4=Der Vollbildschirmmodus könnte schneller oder langsamer
+options.fullscreen.tooltip.5=als der Fenstermodus sein, das kommt auf die Grafik-
+options.fullscreen.tooltip.6=karte an.
 
-of.options.FULLSCREEN_MODE=Vollbildschirmmodus
-of.options.FULLSCREEN_MODE.tooltip.1=Vollbildschirmmodus
-of.options.FULLSCREEN_MODE.tooltip.2=  Standard - Benutze Desktopbildschirmauflösung, langsamer
-of.options.FULLSCREEN_MODE.tooltip.3=  WxH - Benutze eigene Bildschirmauflösung, könnte schneller sein
-of.options.FULLSCREEN_MODE.tooltip.4=Die ausgewählte Auflösung wird im Vollbildschirmmodus verwendet (F11).
-of.options.FULLSCREEN_MODE.tooltip.5=Kleinere Auflösungen sollten generell schneller sein.
+of.options.FULLSCREEN_MODE=Vollbild-Auflösung
+of.options.FULLSCREEN_MODE.tooltip.1=Vollbild-Auflösung
+of.options.FULLSCREEN_MODE.tooltip.2=  Standard - Benutze Bildschirmauflösung, langsamer
+of.options.FULLSCREEN_MODE.tooltip.3=  WxH - Benutze andere Auflösung, könnte schneller sein
+of.options.FULLSCREEN_MODE.tooltip.4=Die ausgewählte Auflösung wird im Vollbildschirmmodus
+of.options.FULLSCREEN_MODE.tooltip.5=verwendet (F11). Kleinere Auflösungen sollten generell
+of.options.FULLSCREEN_MODE.tooltip.5=schneller sein.
 
-of.options.SHOW_FPS=Zeige FPS
-of.options.SHOW_FPS.tooltip.1=Zeige kurze FPS- und Render-Informationen
+of.options.SHOW_FPS=Bildrate anzeigen
+of.options.SHOW_FPS.tooltip.1=Zeige kurze Bildrate- und Render-Informationen
 of.options.SHOW_FPS.tooltip.2=  C: - Chunkrenderer
 of.options.SHOW_FPS.tooltip.3=  E: - Objektrenderer + Blockrenderer
 of.options.SHOW_FPS.tooltip.4=  U: - Chunk-Aktualisierungen
-of.options.SHOW_FPS.tooltip.5=Die kurze FPS-Informationen werden nur gezeigt, wenn der
+of.options.SHOW_FPS.tooltip.5=Die Bildrate-Informationen werden nur gezeigt, wenn der
 of.options.SHOW_FPS.tooltip.6=Debugbildschirm (F3) sichtbar ist.
 
 of.options.save.default=Standard (2s)
@@ -517,6 +541,4 @@ of.options.save.30min=30min
 of.options.AUTOSAVE_TICKS=Autospeichern
 of.options.AUTOSAVE_TICKS.tooltip.1=Autospeicherintervall
 of.options.AUTOSAVE_TICKS.tooltip.2=Normales Autospeicherintervall (2s) ist NICHT EMPFOHLEN.
-of.options.AUTOSAVE_TICKS.tooltip.3=Autospeichern verursacht die berühmte Lag-Spitze des Todes.
-
-options.anaglyph.tooltip.1=3D-Modus kann nur mit einer Rot-Cyan-Brille benutzt werden.
+of.options.AUTOSAVE_TICKS.tooltip.3=Autospeichern verursacht den berühmten Lag des Todes.


### PR DESCRIPTION
(Almost) everything should fit onto those buttons and tooltips now. Some strings were rather tricky to adjust and still don't quite fit.
Also adapted several translations from the official Minecraft translation (space between word and ... to not make it an abbreviation for example; `Bildrate` for `fps`; `ON` and `OFF` are not in caps lock in German; etc).