### PR TITLE
Fix German Translation for Brightness Tooltips

### DIFF
--- a/OptiFineDoc/assets/minecraft/optifine/lang/de_DE.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/de_DE.lang
@@ -89,9 +89,10 @@ options.vbo.tooltip.3=schneller (5-10%%) als das Standard-Rendermodell ist.
 
 options.gamma.tooltip.1=Erhöht die Helligkeit dunkler Objekte
 options.gamma.tooltip.2=  Düster - Standardhelligkeit
-options.gamma.tooltip.3=  Hell - Maximale Helligkeit für dunkle Objekte
-options.gamma.tooltip.4=Diese Einstellungen ändern nicht die Helligkeit von ganz
-options.gamma.tooltip.5=schwarzen Objekten
+options.gamma.tooltip.3=  1-99%% - veränderlich
+options.gamma.tooltip.4=  Hell - Maximale Helligkeit für dunkle Objekte
+options.gamma.tooltip.5=Diese Einstellungen ändern nicht die Helligkeit von ganz
+options.gamma.tooltip.6=schwarzen Objekten
 
 options.anaglyph.tooltip.1=3D-Modus
 options.anaglyph.tooltip.2=Kann nur mit einer Rot-Cyan-Brille benutzt werden.


### PR DESCRIPTION
For the German translation of the Brightness tooltips there is:
options.gamma.tooltip.3= 1-99%% - variable
missing, which results in the last line appearing in the stock English language as there are overall only 5 tooltips.
![image](https://cloud.githubusercontent.com/assets/16366556/15410842/4a010e0c-1e1c-11e6-9541-9587c642e7f6.png)
