### PR TITLE
pt_br.lang - fix(format error) added %%

### DIFF
--- a/OptiFineDoc/assets/minecraft/optifine/lang/pt_br.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/pt_br.lang
@@ -1,4 +1,4 @@
-# Translator = Diego R. V.
+# Translator: Diego R. V. (04/16/2018)
 
 # General
 of.general.ambiguous=ambíguo
@@ -54,8 +54,8 @@ of.message.loadingVisibleChunks=Carregando chunks visíveis
 options.graphics.tooltip.1=Qualidade visual
 options.graphics.tooltip.2=  Rápida  - baixa qualidade, rápida
 options.graphics.tooltip.3=  Bonita - alta qualidade, lenta
-options.graphics.tooltip.4=Altera a aparência de nuvens, folhas,
-options.graphics.tooltip.5=água, sombras e grama.
+options.graphics.tooltip.4=Altera a aparência de nuvens, folhas, água,
+options.graphics.tooltip.5=sombras e grama.
 
 of.options.renderDistance.tiny=Mínima
 of.options.renderDistance.short=Curta
@@ -69,29 +69,29 @@ options.renderDistance.tooltip.1=Distância visível
 options.renderDistance.tooltip.2=  2 Mínima - 32m (muito rápida)
 options.renderDistance.tooltip.3=  8 Normal - 128m (normal)
 options.renderDistance.tooltip.4=  16 Longa - 256m (lenta)
-options.renderDistance.tooltip.5=  32 Extrema - 512m (muito lenta!)
+options.renderDistance.tooltip.5=  32 Extrema - 512m (muito lenta)
 options.renderDistance.tooltip.6=  48 Insana - 768m, requer 2GB alocados para RAM
 options.renderDistance.tooltip.7=  64 Máxima - 1024m, requer 3GB alocados para RAM
-options.renderDistance.tooltip.8=Valores superiores à 16 Longa funcionam apenas em mundos locais.
+options.renderDistance.tooltip.8=Valores acima de 16 funcionam apenas em mundos locais.
 
 options.ao.tooltip.1=Iluminação suave
-options.ao.tooltip.2=  Não - desativar iluminação suave (rápida)
-options.ao.tooltip.3=  Mínima - iluminação simples (lenta)
-options.ao.tooltip.4=  Máxima - iluminação refinada (muito lenta)
+options.ao.tooltip.2=  Não - sem iluminação suave (rápida)
+options.ao.tooltip.3=  Mínima - iluminação suave simples (lenta)
+options.ao.tooltip.4=  Máxima - iluminação suave realista (mais lenta)
 
 options.framerateLimit.tooltip.1=Limite de quadros
-options.framerateLimit.tooltip.2=  VSync - limita a taxa de quadros (60, 30, 20)
+options.framerateLimit.tooltip.2=  VSync - taxa de quadros limitada (60, 30, 20)
 options.framerateLimit.tooltip.3=  5-255 - variável
-options.framerateLimit.tooltip.4=  Ilimitado - máxima (rápida)
-options.framerateLimit.tooltip.5=A taxa de quadros cairá se o valor
-options.framerateLimit.tooltip.6=definido não for atingido.
+options.framerateLimit.tooltip.4=  Ilimitada - máxima (rápida)
+options.framerateLimit.tooltip.5=A taxa de quadros cairá se o valor definido não
+options.framerateLimit.tooltip.6=for atingido.
 of.options.framerateLimit.vsync=VSync
 
-of.options.AO_LEVEL=Nível de ilumin. suave
+of.options.AO_LEVEL=Nível de ilum. suave
 of.options.AO_LEVEL.tooltip.1=Nível de iluminação suave
 of.options.AO_LEVEL.tooltip.2=  Não - sem sombras
-of.options.AO_LEVEL.tooltip.3=  50% - sombras claras
-of.options.AO_LEVEL.tooltip.4=  100% - sombras escuras
+of.options.AO_LEVEL.tooltip.3=  50%% - sombras claras
+of.options.AO_LEVEL.tooltip.4=  100%% - sombras escuras
 
 options.viewBobbing.tooltip.1=Balanço da visão
 options.viewBobbing.tooltip.2=Desative esta opção para melhores resultados em mipmaps.
@@ -100,17 +100,17 @@ options.guiScale.tooltip.1=Interface
 options.guiScale.tooltip.2=  Automática - maior possível
 options.guiScale.tooltip.3=  Pequena, Normal, Grande - 1x para 3x
 options.guiScale.tooltip.4=  4x para 10x - disponível em monitores 4K
-options.guiScale.tooltip.5=Valores únicos (1x, 3x, 5x ...) são incompatíveis com Unicode.
-options.guiScale.tooltip.6=Uma interface menor pode ampliar o desempenho.
+options.guiScale.tooltip.5=Valores únicos (1x, 3x, 5x ...) são incompatíveis com
+options.guiScale.tooltip.6=Unicode. Uma interface menor pode ampliar o desempenho.
 
 options.vbo.tooltip.1=Vertex Buffer Objects
-options.vbo.tooltip.2=Utiliza um modelo de renderização mais
-options.vbo.tooltip.3=rápido (5-10%) do que o modelo comum.
+options.vbo.tooltip.2=Utiliza um modelo de renderização mais eficiente
+options.vbo.tooltip.3=(5-10%%) do que o modelo comum.
 
 options.gamma.tooltip.1=Suaviza o brilho de objetos escuros.
 options.gamma.tooltip.2=  Escuro - brilho normal
-options.gamma.tooltip.3=  1-99% - variável
-options.gamma.tooltip.4=  Claro - maior brilho para objetos escuros
+options.gamma.tooltip.3=  1-99%% - variável
+options.gamma.tooltip.4=  Claro - brilho intenso em objetos escuros
 options.gamma.tooltip.5=Esta opção não clareia
 options.gamma.tooltip.6=objetos totalmente escuros.
 
@@ -121,16 +121,16 @@ options.anaglyph.tooltip.4=Requer óculos vermelho-ciano para melhores resultado
 
 of.options.ALTERNATE_BLOCKS=Blocos alternados
 of.options.ALTERNATE_BLOCKS.tooltip.1=Blocos alternados
-of.options.ALTERNATE_BLOCKS.tooltip.2=Utiliza modelos alternativos para alguns blocos.
+of.options.ALTERNATE_BLOCKS.tooltip.2=Utiliza modelos alternativos para certos blocos.
 of.options.ALTERNATE_BLOCKS.tooltip.3=Depende do pacote de recursos escolhido pelo jogador.
 
 of.options.FOG_FANCY=Névoa
 of.options.FOG_FANCY.tooltip.1=Tipo de névoa
-of.options.FOG_FANCY.tooltip.2=  Rápida - não reduz a taxa de quadros
-of.options.FOG_FANCY.tooltip.3=  Suave - reduz a taxa de quadros
+of.options.FOG_FANCY.tooltip.2=  Rápida - taxa de quadros elevada
+of.options.FOG_FANCY.tooltip.3=  Suave - taxa de quadros reduzida
 of.options.FOG_FANCY.tooltip.4=  Não - névoa desativada
-of.options.FOG_FANCY.tooltip.5=A névoa suave estará disponível apenas se sua placa
-of.options.FOG_FANCY.tooltip.6=de vídeo permitir.
+of.options.FOG_FANCY.tooltip.5=A névoa suave estará disponível apenas
+of.options.FOG_FANCY.tooltip.6=se sua placa de vídeo permitir.
 
 of.options.FOG_START=Início da névoa
 of.options.FOG_START.tooltip.1=Início da névoa
@@ -140,17 +140,17 @@ of.options.FOG_START.tooltip.4=Normalmente, esta opção não afeta o desempenho
 
 of.options.CHUNK_LOADING=Carreg. de chunks
 of.options.CHUNK_LOADING.tooltip.1=Carregamento de chunks
-of.options.CHUNK_LOADING.tooltip.2=  Padrão - FPS instável ao carregar os chunks
-of.options.CHUNK_LOADING.tooltip.3=  Smooth - FPS estável
-of.options.CHUNK_LOADING.tooltip.4=  Multi-Core - FPS estável e carregamento 3x mais rápido
+of.options.CHUNK_LOADING.tooltip.2=  Padrão - taxa de quadros instável ao carregar chunks
+of.options.CHUNK_LOADING.tooltip.3=  Smooth - taxa de quadros estável
+of.options.CHUNK_LOADING.tooltip.4=  Multi-Core - taxa de quadros estável e carregamento 3x mais rápido
 of.options.CHUNK_LOADING.tooltip.5=Smooth e Multi-Core reduzem a latência
 of.options.CHUNK_LOADING.tooltip.6=causada pelo carregamento de chunks.
 of.options.CHUNK_LOADING.tooltip.7=O Multi-Core pode aumentar em 3x o carregamento
-of.options.CHUNK_LOADING.tooltip.8=e a taxa de quadros usando outro processador.
+of.options.CHUNK_LOADING.tooltip.8=e a taxa de quadros utilizando outro processador.
 of.options.chunkLoading.smooth=Smooth
 of.options.chunkLoading.multiCore=Multi-Core
 
-of.options.shaders=Shaders...
+of.options.shaders=Shaders
 of.options.shadersTitle=Shaders
 
 of.options.shaders.packNone=Não
@@ -183,7 +183,7 @@ of.options.shaders.SPECULAR_MAP.tooltip.5=para simular efeitos reflexivos especi
 of.options.shaders.SPECULAR_MAP.tooltip.6=Texturas de mapas especulares são incluídas no
 of.options.shaders.SPECULAR_MAP.tooltip.7=pacote de recursos atual.
 
-of.options.shaders.RENDER_RES_MUL=Qualidade de render.
+of.options.shaders.RENDER_RES_MUL=Render.
 of.options.shaders.RENDER_RES_MUL.tooltip.1=Qualidade de renderização
 of.options.shaders.RENDER_RES_MUL.tooltip.2=  0.5x - baixa (rápida)
 of.options.shaders.RENDER_RES_MUL.tooltip.3=  1x - padrão
@@ -191,15 +191,15 @@ of.options.shaders.RENDER_RES_MUL.tooltip.4=  2x - alta (lenta)
 of.options.shaders.RENDER_RES_MUL.tooltip.5=A qualidade de renderização controla o tamanho
 of.options.shaders.RENDER_RES_MUL.tooltip.6=da textura renderizada pelo pacote Shaders.
 of.options.shaders.RENDER_RES_MUL.tooltip.7=Valores menores funcionam melhor em monitores 4K.
-of.options.shaders.RENDER_RES_MUL.tooltip.8=Valores maiores funcionam com um filtro de Antialiasing.
+of.options.shaders.RENDER_RES_MUL.tooltip.8=Valores maiores funcionam com o filtro de Antialiasing.
 
-of.options.shaders.SHADOW_RES_MUL=Qualidade de sombras
+of.options.shaders.SHADOW_RES_MUL=Sombra
 of.options.shaders.SHADOW_RES_MUL.tooltip.1=Qualidade de sombras
 of.options.shaders.SHADOW_RES_MUL.tooltip.2=  0.5x - baixa (rápida)
 of.options.shaders.SHADOW_RES_MUL.tooltip.3=  1x - padrão
 of.options.shaders.SHADOW_RES_MUL.tooltip.4=  2x - alta (lenta)
-of.options.shaders.SHADOW_RES_MUL.tooltip.5=A qualidade de sombras controla o tamanho das texturas de sombras
-of.options.shaders.SHADOW_RES_MUL.tooltip.6=utilizadas pelo pacote Shaders atual.
+of.options.shaders.SHADOW_RES_MUL.tooltip.5=A qualidade de sombras controla o tamanho das texturas
+of.options.shaders.SHADOW_RES_MUL.tooltip.6=de sombras utilizadas pelo pacote Shaders atual.
 of.options.shaders.SHADOW_RES_MUL.tooltip.7=Valores baixos = sombras distorcidas.
 of.options.shaders.SHADOW_RES_MUL.tooltip.8=Valores altos = sombras suavizadas.
 
@@ -208,14 +208,14 @@ of.options.shaders.HAND_DEPTH_MUL.tooltip.1=Profundidade da mão
 of.options.shaders.HAND_DEPTH_MUL.tooltip.2=  0.5x - mão próxima à câmera
 of.options.shaders.HAND_DEPTH_MUL.tooltip.3=  1x - (padrão)
 of.options.shaders.HAND_DEPTH_MUL.tooltip.4=  2x - mão distante da câmera
-of.options.shaders.HAND_DEPTH_MUL.tooltip.5=A profundidade da mão controla o quão longe os
-of.options.shaders.HAND_DEPTH_MUL.tooltip.6=itens segurados estão da câmera
-of.options.shaders.HAND_DEPTH_MUL.tooltip.7=Esta opção pode alterar o efeito embaçado de profundidade, fornecido por pacotes Shaders,
-of.options.shaders.HAND_DEPTH_MUL.tooltip.8=de itens segurados.
+of.options.shaders.HAND_DEPTH_MUL.tooltip.5=A profundidade da mão controla o quão
+of.options.shaders.HAND_DEPTH_MUL.tooltip.6=longe os itens segurados estão da câmera.
+of.options.shaders.HAND_DEPTH_MUL.tooltip.7=Esta opção pode alterar o efeito embaçado de profundidade,
+of.options.shaders.HAND_DEPTH_MUL.tooltip.8=fornecido por pacotes Shaders, de itens segurados.
 
 of.options.shaders.CLOUD_SHADOW=Sombra das nuvens
 
-of.options.shaders.OLD_HAND_LIGHT=Iluminação pela mão
+of.options.shaders.OLD_HAND_LIGHT=Ilum. pela mão
 of.options.shaders.OLD_HAND_LIGHT.tooltip.1=Iluminação antiga pela mão
 of.options.shaders.OLD_HAND_LIGHT.tooltip.2=  Padrão - definida pelo pacote Shaders
 of.options.shaders.OLD_HAND_LIGHT.tooltip.3=  Sim - habilitar iluminação antiga pela mão
@@ -224,13 +224,13 @@ of.options.shaders.OLD_HAND_LIGHT.tooltip.5=A iluminação antiga pela mão perm
 of.options.shaders.OLD_HAND_LIGHT.tooltip.6=reconheça a emissão de luzes por itens na mão principal
 of.options.shaders.OLD_HAND_LIGHT.tooltip.7=para que seja possível segurar itens com a mão secundária.
 
-of.options.shaders.OLD_LIGHTING=Iluminação antiga
+of.options.shaders.OLD_LIGHTING=Ilum. antiga
 of.options.shaders.OLD_LIGHTING.tooltip.1=Iluminação antiga
 of.options.shaders.OLD_LIGHTING.tooltip.2=  Padrão - definida pelo pacote Shaders
 of.options.shaders.OLD_LIGHTING.tooltip.3=  Sim - habilitar iluminação antiga
 of.options.shaders.OLD_LIGHTING.tooltip.4=  Não - desabilitar iluminação antiga
 of.options.shaders.OLD_LIGHTING.tooltip.5=A iluminação antiga controla luzes fixas
-of.options.shaders.OLD_LIGHTING.tooltip.6=padronizadas aplicadas aos blocos
+of.options.shaders.OLD_LIGHTING.tooltip.6=padronizadas aplicadas aos blocos.
 of.options.shaders.OLD_LIGHTING.tooltip.7=Pacotes Shaders que fornecem efeitos de sombras geralmente
 of.options.shaders.OLD_LIGHTING.tooltip.8=tornam a iluminação mais realista, dependendo da posição do Sol.
 
@@ -275,15 +275,15 @@ of.options.mipmap.nearest=Próximo
 of.options.mipmap.trilinear=Trilinear
 
 options.mipmapLevels.tooltip.1=Efeito visual que aperfeiçoa a aparência de objetos
-options.mipmapLevels.tooltip.2=distantes, suavizando detalhes de texturas
-options.mipmapLevels.tooltip.3=  Não - Nenhuma suavização
-options.mipmapLevels.tooltip.4=  1 - Suavização mínima
-options.mipmapLevels.tooltip.5=  4 - Suavização máxima
+options.mipmapLevels.tooltip.2=distantes, suavizando detalhes de texturas.
+options.mipmapLevels.tooltip.3=  Não - não suavizar
+options.mipmapLevels.tooltip.4=  1 - suavização mínima
+options.mipmapLevels.tooltip.5=  4 - suavização máxima
 options.mipmapLevels.tooltip.6=Esta opção não afeta o desempenho.
 
 of.options.MIPMAP_TYPE=Tipo de mipmap
-of.options.MIPMAP_TYPE.tooltip.1=Efeito visual que melhora a aparência de objetos distantes,
-of.options.MIPMAP_TYPE.tooltip.2=suavizando os detalhes de texturas
+of.options.MIPMAP_TYPE.tooltip.1=Efeito visual que melhora a aparência de objetos
+of.options.MIPMAP_TYPE.tooltip.2=distantes, suavizando os detalhes de texturas.
 of.options.MIPMAP_TYPE.tooltip.3=  Próximo - suavização básica (rápida)
 of.options.MIPMAP_TYPE.tooltip.4=  Linear - suavização normal
 of.options.MIPMAP_TYPE.tooltip.5=  Bilinear - suavização refinada
@@ -295,17 +295,17 @@ of.options.AA_LEVEL.tooltip.2= Não - (padrão) desativar Antialiasing (rápido)
 of.options.AA_LEVEL.tooltip.3= 2-16 - linhas e bordas suavizadas (lento)
 of.options.AA_LEVEL.tooltip.4=O Antialiasing suaviza linhas
 of.options.AA_LEVEL.tooltip.5=irregulares e transições de cores.
-of.options.AA_LEVEL.tooltip.6=Quando ativado, pode reduzir significativamente a taxa de quadros.
-of.options.AA_LEVEL.tooltip.7=Nem todos os níveis acima são suportados por todas as placas de vídeo.
-of.options.AA_LEVEL.tooltip.8=REINICIE ao alterar!
+of.options.AA_LEVEL.tooltip.6=Quando ativado, pode reduzir significativamente a taxa
+of.options.AA_LEVEL.tooltip.7=de quadros. Nem todos os níveis acima são suportados por todas as
+of.options.AA_LEVEL.tooltip.8=as placas de vídeo. REINICIE ao alterar!
 
 of.options.AF_LEVEL=Filtragem Anisotrópica
 of.options.AF_LEVEL.tooltip.1=Filtragem Anisotrópica
 of.options.AF_LEVEL.tooltip.2= Não - (padrão) detalhes padrões da textura (rápida)
 of.options.AF_LEVEL.tooltip.3= 2-16 - melhores detalhes em texturas de mipmap (lenta)
-of.options.AF_LEVEL.tooltip.4=A Filtragem Anisotrópica restaura
-of.options.AF_LEVEL.tooltip.5=detalhes em texturas de mipmap.
-of.options.AF_LEVEL.tooltip.6=Quando ativada, pode reduzir significativamente a taxa de quadros.
+of.options.AF_LEVEL.tooltip.4=A Filtragem Anisotrópica restaura detalhes em
+of.options.AF_LEVEL.tooltip.5=texturas de mipmap. Quando ativada, pode
+of.options.AF_LEVEL.tooltip.6=reduzir significativamente a taxa de quadros.
 
 of.options.CLEAR_WATER=Água límpida
 of.options.CLEAR_WATER.tooltip.1=Água límpida
@@ -314,50 +314,50 @@ of.options.CLEAR_WATER.tooltip.3=  Não - água normal
 
 of.options.RANDOM_ENTITIES=Entidades aleatórias
 of.options.RANDOM_ENTITIES.tooltip.1=Entidades aleatórias
-of.options.RANDOM_ENTITIES.tooltip.2=  Não - sem entidades aleatórias, rápido
-of.options.RANDOM_ENTITIES.tooltip.3=  Sim - entidades aleatórias, lento
-of.options.RANDOM_ENTITIES.tooltip.4=Entidades aleatórias utilizam texturas randômicas.
-of.options.RANDOM_ENTITIES.tooltip.5=Requer um pacote de recursos com múltiplas texturas de entidades.
+of.options.RANDOM_ENTITIES.tooltip.2=  Não - sem entidades aleatórias, rápida
+of.options.RANDOM_ENTITIES.tooltip.3=  Sim - entidades aleatórias, lenta
+of.options.RANDOM_ENTITIES.tooltip.4=Entidades aleatórias utilizam texturas randômicas. Requer
+of.options.RANDOM_ENTITIES.tooltip.5=um pacote de recursos com múltiplas texturas de entidades.
 
 of.options.BETTER_GRASS=Better Grass
 of.options.BETTER_GRASS.tooltip.1=Better Grass
-of.options.BETTER_GRASS.tooltip.2=  Não - textura comum da grama, rápido
-of.options.BETTER_GRASS.tooltip.3=  Rápido - textura integrada da grama, lento
-of.options.BETTER_GRASS.tooltip.4=  Bonito - textura dinâmica da grama, mais lento
+of.options.BETTER_GRASS.tooltip.2=  Não - textura comum da grama, rápida
+of.options.BETTER_GRASS.tooltip.3=  Rápido - textura integrada da grama, lenta
+of.options.BETTER_GRASS.tooltip.4=  Bonito - textura dinâmica da grama, mais lenta
 
 of.options.BETTER_SNOW=Better Snow
 of.options.BETTER_SNOW.tooltip.1=Better Snow
-of.options.BETTER_SNOW.tooltip.2=  Não - neve normal, rápido
-of.options.BETTER_SNOW.tooltip.3=  Sim - neve integrada, lento
-of.options.BETTER_SNOW.tooltip.4=Exibe a neve integrada ao redor de
-of.options.BETTER_SNOW.tooltip.5=blocos como cercas e flores.
+of.options.BETTER_SNOW.tooltip.2=  Não - neve normal, rápida
+of.options.BETTER_SNOW.tooltip.3=  Sim - neve integrada, lenta
+of.options.BETTER_SNOW.tooltip.4=Exibe a neve integrada ao redor
+of.options.BETTER_SNOW.tooltip.5=de blocos como cercas e flores.
 
-of.options.CUSTOM_FONTS=Fontes personal.
+of.options.CUSTOM_FONTS=Fontes personalizadas
 of.options.CUSTOM_FONTS.tooltip.1=Fontes personalizadas
-of.options.CUSTOM_FONTS.tooltip.2=  Sim - Utilizar fontes personalizadas (padrão), lento
-of.options.CUSTOM_FONTS.tooltip.3=  Não - Utilizar fontes comuns, rápido
+of.options.CUSTOM_FONTS.tooltip.2=  Sim - Utilizar fontes personalizadas (padrão), lentas
+of.options.CUSTOM_FONTS.tooltip.3=  Não - Utilizar fontes comuns, rápidas
 of.options.CUSTOM_FONTS.tooltip.4=As fontes personalizadas, se houver, são
 of.options.CUSTOM_FONTS.tooltip.5=fornecidas pelo pacote de recursos atual.
 
-of.options.CUSTOM_COLORS=Cores personal.
+of.options.CUSTOM_COLORS=Cores personalizadas
 of.options.CUSTOM_COLORS.tooltip.1=Cores personalizadas
-of.options.CUSTOM_COLORS.tooltip.2=  Sim - Utilizar cores personalizadas (padrão), lento
-of.options.CUSTOM_COLORS.tooltip.3=  Não - Utilizar cores comuns, rápido
+of.options.CUSTOM_COLORS.tooltip.2=  Sim - Utilizar cores personalizadas (padrão), lentas
+of.options.CUSTOM_COLORS.tooltip.3=  Não - Utilizar cores comuns, rápidas
 of.options.CUSTOM_COLORS.tooltip.4=As cores personalizadas, se houver, são
 of.options.CUSTOM_COLORS.tooltip.5=fornecidas pelo pacote de recursos atual.
 
 of.options.SWAMP_COLORS=Cores do Pântano
 of.options.SWAMP_COLORS.tooltip.1=Cores do bioma Pântano
-of.options.SWAMP_COLORS.tooltip.2=  Sim - exibir cores do Pântano (padrão), lento
-of.options.SWAMP_COLORS.tooltip.3=  Não - desabilitar cores do Pântano, rápido
+of.options.SWAMP_COLORS.tooltip.2=  Sim - habilitar cores do Pântano (padrão), lentas
+of.options.SWAMP_COLORS.tooltip.3=  Não - desabilitar cores do Pântano, rápidas
 of.options.SWAMP_COLORS.tooltip.4=As cores alteram os aspectos da vegetação e água do bioma.
 
 of.options.SMOOTH_BIOMES=Smooth Biomes
 of.options.SMOOTH_BIOMES.tooltip.1=Smooth Biomes
-of.options.SMOOTH_BIOMES.tooltip.2=  Sim - integrar bordas dos biomas (padrão), lento
-of.options.SMOOTH_BIOMES.tooltip.3=  Não - sem suavização das bordas dos biomas, rápido
-of.options.SMOOTH_BIOMES.tooltip.4=A integração das bordas dos biomas é feita
-of.options.SMOOTH_BIOMES.tooltip.5=pela média das cores dos blocos ao redor.
+of.options.SMOOTH_BIOMES.tooltip.2=  Sim - integrar bordas de biomas (padrão), lentas
+of.options.SMOOTH_BIOMES.tooltip.3=  Não - não suavizar bordas de biomas, rápidas
+of.options.SMOOTH_BIOMES.tooltip.4=A transição das bordas de biomas é feita
+of.options.SMOOTH_BIOMES.tooltip.5=pela média das matizes dos blocos ao redor.
 of.options.SMOOTH_BIOMES.tooltip.6=Esta opção altera os aspectos da vegetação e água.
 
 of.options.CONNECTED_TEXTURES=Texturas conectadas
@@ -375,97 +375,97 @@ of.options.NATURAL_TEXTURES.tooltip.1=Texturas naturais
 of.options.NATURAL_TEXTURES.tooltip.2=  Não - texturas naturais desativadas (padrão)
 of.options.NATURAL_TEXTURES.tooltip.3=  Sim - texturas naturais ativadas
 of.options.NATURAL_TEXTURES.tooltip.4=As texturas naturais reduzem a aparência
-of.options.NATURAL_TEXTURES.tooltip.5=linear dos blocos do mesmo tipo.
-of.options.NATURAL_TEXTURES.tooltip.6=Utiliza variantes da base da textura
-of.options.NATURAL_TEXTURES.tooltip.7=do bloco. A configuração é definida
-of.options.NATURAL_TEXTURES.tooltip.8=pelo pacote de recursos atual.
+of.options.NATURAL_TEXTURES.tooltip.5=linear dos blocos do mesmo tipo. Utiliza
+of.options.NATURAL_TEXTURES.tooltip.6=variantes da base da textura do bloco.
+of.options.NATURAL_TEXTURES.tooltip.7=A configuração é definida pelo pacote de
+of.options.NATURAL_TEXTURES.tooltip.8=recursos atual.
 
 of.options.EMISSIVE_TEXTURES=Texturas emissivas
 of.options.EMISSIVE_TEXTURES.tooltip.1=Texturas emissivas
 of.options.EMISSIVE_TEXTURES.tooltip.2=  Não - sem texturas emissivas (padrão)
 of.options.EMISSIVE_TEXTURES.tooltip.3=  Sim - com texturas emissivas
 of.options.EMISSIVE_TEXTURES.tooltip.4=Texturas emissivas são renderizadas como sobreposições
-of.options.EMISSIVE_TEXTURES.tooltip.5=com brilho total. Podem ser usadas para simular
-of.options.EMISSIVE_TEXTURES.tooltip.6=emissões de luz da textura base.
+of.options.EMISSIVE_TEXTURES.tooltip.5=com brilho total. Podem ser usadas para
+of.options.EMISSIVE_TEXTURES.tooltip.6=simular emissões de luz da textura base.
 of.options.EMISSIVE_TEXTURES.tooltip.7=As texturas emissivas, se houver, são
 of.options.EMISSIVE_TEXTURES.tooltip.8=fornecidas pelo pacote de recursos atual.
 
-of.options.CUSTOM_SKY=Céu personal.
+of.options.CUSTOM_SKY=Céu personalizado
 of.options.CUSTOM_SKY.tooltip.1=Céu personalizado
 of.options.CUSTOM_SKY.tooltip.2=  Sim - textura personalizada do céu (padrão), lento
 of.options.CUSTOM_SKY.tooltip.3=  Não - textura comum do céu, rápido
 of.options.CUSTOM_SKY.tooltip.4=As texturas personalizadas do céu, se houver,
 of.options.CUSTOM_SKY.tooltip.5=são fornecidas pelo pacote de recursos atual.
 
-of.options.CUSTOM_ITEMS=Itens personal.
+of.options.CUSTOM_ITEMS=Itens personalizados
 of.options.CUSTOM_ITEMS.tooltip.1=Itens personalizados
-of.options.CUSTOM_ITEMS.tooltip.2=  Sim - texturas personalizadas de itens (padrão), lento
-of.options.CUSTOM_ITEMS.tooltip.3=  Não - texturas normais de itens, rápido
+of.options.CUSTOM_ITEMS.tooltip.2=  Sim - texturas personalizadas de itens (padrão), lentos
+of.options.CUSTOM_ITEMS.tooltip.3=  Não - texturas comuns de itens, rápidos
 of.options.CUSTOM_ITEMS.tooltip.4=Αs texturas personalizadas de itens, se houver,
 of.options.CUSTOM_ITEMS.tooltip.5=são fornecidas pelo pacote de recursos atual.
 
 of.options.CUSTOM_ENTITY_MODELS=Modelos de entidades
 of.options.CUSTOM_ENTITY_MODELS.tooltip.1=Modelos personalizados de entidades
-of.options.CUSTOM_ENTITY_MODELS.tooltip.2=  Sim - modelos personalizados de entidades (padrão), lento
-of.options.CUSTOM_ENTITY_MODELS.tooltip.3=  Não - modelos comuns de entidades, rápido
+of.options.CUSTOM_ENTITY_MODELS.tooltip.2=  Sim - modelos personalizados de entidades (padrão), lentos
+of.options.CUSTOM_ENTITY_MODELS.tooltip.3=  Não - modelos comuns de entidades, rápidos
 of.options.CUSTOM_ENTITY_MODELS.tooltip.4=Os modelos personalizados de entidades, se houver,
 of.options.CUSTOM_ENTITY_MODELS.tooltip.5=são fornecidos pelo pacote de recursos atual.
 
 of.options.CUSTOM_GUIS=Interfaces personal.
 of.options.CUSTOM_GUIS.tooltip.1=Interfaces personalizadas
-of.options.CUSTOM_GUIS.tooltip.2=  Sim - interfaces personalizadas (padrão), lento
-of.options.CUSTOM_GUIS.tooltip.3=  Não - interfaces padrões, rápido
-of.options.CUSTOM_GUIS.tooltip.4=Interfaces personalizadas são fornecidas pelo pacote de recursos atual.
+of.options.CUSTOM_GUIS.tooltip.2=  Sim - interfaces personalizadas (padrão), lentas
+of.options.CUSTOM_GUIS.tooltip.3=  Não - interfaces padrões, rápidas
+of.options.CUSTOM_GUIS.tooltip.4=Interfaces personalizadas são fornecidas por pacote de recursos.
 
 # Details
 
 of.options.CLOUDS=Nuvens
 of.options.CLOUDS.tooltip.1=Nuvens
 of.options.CLOUDS.tooltip.2=  Padrão - como o configurado
-of.options.CLOUDS.tooltip.3=  Rápidas - baixa qualidade, rápido
-of.options.CLOUDS.tooltip.4=  Bonitas - alta qualidade, lento
-of.options.CLOUDS.tooltip.5=  Não - sem nuvens, mais rápido
+of.options.CLOUDS.tooltip.3=  Rápidas - baixa qualidade
+of.options.CLOUDS.tooltip.4=  Bonitas - alta qualidade
+of.options.CLOUDS.tooltip.5=  Não - desabilitar nuvens, mais rápido
 of.options.CLOUDS.tooltip.6=Nuvens rápidas - 2D.
 of.options.CLOUDS.tooltip.7=Nuvens bonitas - 3D.
 
 of.options.CLOUD_HEIGHT=Altitude das nuvens
 of.options.CLOUD_HEIGHT.tooltip.1=Altitude das nuvens
 of.options.CLOUD_HEIGHT.tooltip.2=  Não - padrão
-of.options.CLOUD_HEIGHT.tooltip.3=  100% - acima do limite de altura do mundo
+of.options.CLOUD_HEIGHT.tooltip.3=  100%% - acima do limite de altura do mundo
 
 of.options.TREES=Árvores
 of.options.TREES.tooltip.1=Árvores
 of.options.TREES.tooltip.2=  Padrão - como o configurado
-of.options.TREES.tooltip.3=  Rápidas - baixa qualidade, mais rápido
-of.options.TREES.tooltip.4=  Inteligentes - qualidade razoável, rápido
-of.options.TREES.tooltip.5=  Bonitas - alta qualidade, lento
+of.options.TREES.tooltip.3=  Rápidas - baixa qualidade, mais rápidas
+of.options.TREES.tooltip.4=  Inteligentes - qualidade razoável, rápidas
+of.options.TREES.tooltip.5=  Bonitas - alta qualidade, lentas
 of.options.TREES.tooltip.6=Na opção Rápidas, as árvores têm folhas opacas.
 of.options.TREES.tooltip.7=Folhas de árvores Bonitas e Inteligentes são transparentes.
 
-of.options.RAIN=Chuva e Neve
-of.options.RAIN.tooltip.1=Chuva e Neve
+of.options.RAIN=Chuva & Neve
+of.options.RAIN.tooltip.1=Chuva & Neve
 of.options.RAIN.tooltip.2=  Padrão - como o configurado
-of.options.RAIN.tooltip.3=  Rápidas  - chuva/neve leve, rápido
-of.options.RAIN.tooltip.4=  Bonitas - chuva/neve densa, lento
-of.options.RAIN.tooltip.5=  Não - chuva/neve desabilitadas, mais rápido
+of.options.RAIN.tooltip.3=  Rápidas  - chuva/neve leve, rápida
+of.options.RAIN.tooltip.4=  Bonitas - chuva/neve densa, lenta
+of.options.RAIN.tooltip.5=  Não - chuva/neve desabilitadas, mais rápida
 of.options.RAIN.tooltip.6=Quando desabilitadas, os sons de
 of.options.RAIN.tooltip.7=precipitação ainda podem estar ativados.
 
 of.options.SKY=Céu
 of.options.SKY.tooltip.1=Céu
-of.options.SKY.tooltip.2=  Sim - Céu ativado, lento
-of.options.SKY.tooltip.3=  Não - Céu desativado, rápido
+of.options.SKY.tooltip.2=  Sim - céu ativado, lento
+of.options.SKY.tooltip.3=  Não - céu desativado, rápido
 of.options.SKY.tooltip.4=Quando o Céu está desativado, a Lua e o Sol ainda podem estar visíveis.
 
 of.options.STARS=Estrelas
 of.options.STARS.tooltip.1=Estrelas
-of.options.STARS.tooltip.2=  Sim - estrelas visíveis, lento
-of.options.STARS.tooltip.3=  Não  - estrelas desativadas, rápido
+of.options.STARS.tooltip.2=  Sim - estrelas visíveis, lentas
+of.options.STARS.tooltip.3=  Não  - estrelas desativadas, rápidas
 
-of.options.SUN_MOON=Sol e Lua
-of.options.SUN_MOON.tooltip.1=Sol e Lua
+of.options.SUN_MOON=Sol & Lua
+of.options.SUN_MOON.tooltip.1=Sol & Lua
 of.options.SUN_MOON.tooltip.2=  Sim - Sol e Lua visíveis (padrão)
-of.options.SUN_MOON.tooltip.3=  Não  - Sol e Lua desativados (rápido)
+of.options.SUN_MOON.tooltip.3=  Não  - Sol e Lua desativados (rápidos)
 
 of.options.SHOW_CAPES=Mostrar capas
 of.options.SHOW_CAPES.tooltip.1=Mostrar capas
@@ -474,11 +474,11 @@ of.options.SHOW_CAPES.tooltip.3=  Não - não mostrar capas de jogadores
 
 of.options.TRANSLUCENT_BLOCKS=Blocos translúcidos
 of.options.TRANSLUCENT_BLOCKS.tooltip.1=Blocos translúcidos
-of.options.TRANSLUCENT_BLOCKS.tooltip.2=  Bonitos - matiz suave das cores (padrão)
-of.options.TRANSLUCENT_BLOCKS.tooltip.3=  Rápidos - matiz rápida de cores (rápido)
-of.options.TRANSLUCENT_BLOCKS.tooltip.4=Controla a matiz de blocos translúcidos
-of.options.TRANSLUCENT_BLOCKS.tooltip.5=de cores diferentes - vidro tingido, água, gelo -
-of.options.TRANSLUCENT_BLOCKS.tooltip.6=quando posicionados atrás de outros com espaço entre eles.
+of.options.TRANSLUCENT_BLOCKS.tooltip.2=  Bonitos - transição de cores (padrão)
+of.options.TRANSLUCENT_BLOCKS.tooltip.3=  Rápidos - transição rápida de cores (rápido)
+of.options.TRANSLUCENT_BLOCKS.tooltip.4=Altera a transição de cores de blocos translúcidos
+of.options.TRANSLUCENT_BLOCKS.tooltip.5=com cores diferentes - vidro tingido, água, gelo - quando
+of.options.TRANSLUCENT_BLOCKS.tooltip.6= posicionados atrás uns dos outros com espaços entre eles
 
 of.options.HELD_ITEM_TOOLTIPS=Descrições de itens
 of.options.HELD_ITEM_TOOLTIPS.tooltip.1=Descrições de itens
@@ -496,8 +496,8 @@ of.options.ADVANCED_TOOLTIPS.tooltip.6=(ex. ID, fonte, valor padrão).
 of.options.DROPPED_ITEMS=Itens no chão
 of.options.DROPPED_ITEMS.tooltip.1=Itens no chão
 of.options.DROPPED_ITEMS.tooltip.2=  Padrão - como o configurado
-of.options.DROPPED_ITEMS.tooltip.3=  Rápido - itens em 2D no chão , rápido
-of.options.DROPPED_ITEMS.tooltip.4=  Bonito - itens em 3D no chão, lento
+of.options.DROPPED_ITEMS.tooltip.3=  Rápido - itens em 2D no chão , rápidos
+of.options.DROPPED_ITEMS.tooltip.4=  Bonito - itens em 3D no chão, lentos
 
 options.entityShadows.tooltip.1=Sombras de entidades
 options.entityShadows.tooltip.2=  Sim - mostrar sombras de entidades
@@ -517,38 +517,38 @@ of.options.DYNAMIC_FOV=Visão dinâmica
 of.options.DYNAMIC_FOV.tooltip.1=Campo de visão dinâmico
 of.options.DYNAMIC_FOV.tooltip.2=  Sim - ativar o campo de visão dinâmico (padrão)
 of.options.DYNAMIC_FOV.tooltip.3=  Não - desativar o campo de visão dinâmico
-of.options.DYNAMIC_FOV.tooltip.4=Altera o campo de visão ao voar,
-of.options.DYNAMIC_FOV.tooltip.5=correr ou retesar um arco.
+of.options.DYNAMIC_FOV.tooltip.4=Altera o campo de visão ao voar, correr ou retesar
+of.options.DYNAMIC_FOV.tooltip.5=um arco.
 
 of.options.DYNAMIC_LIGHTS=Luzes dinâmicas
 of.options.DYNAMIC_LIGHTS.tooltip.1=Luzes dinâmicas
 of.options.DYNAMIC_LIGHTS.tooltip.2=  Não - luzes comuns (padrão)
-of.options.DYNAMIC_LIGHTS.tooltip.3=  Rápido - luzes dinâmicas rápidas (atualizadas a cada 500 milissegundos)
-of.options.DYNAMIC_LIGHTS.tooltip.4=  Bonito - luzes dinâmicas suaves (atualizadas em tempo real)
+of.options.DYNAMIC_LIGHTS.tooltip.3=  Rápido - luzes dinâmicas rápidas (a cada 500 ms)
+of.options.DYNAMIC_LIGHTS.tooltip.4=  Bonito - luzes dinâmicas suaves (em tempo real)
 of.options.DYNAMIC_LIGHTS.tooltip.5=Ativa a emissão de luzes por objetos
-of.options.DYNAMIC_LIGHTS.tooltip.6=(tochas, pedras luminosas etc.) quando
-of.options.DYNAMIC_LIGHTS.tooltip.7=segurados ou caídos no chão.
+of.options.DYNAMIC_LIGHTS.tooltip.6=(ex. tochas, pedras luminosas)
+of.options.DYNAMIC_LIGHTS.tooltip.7=quando segurados ou caídos no chão.
 
 # Performance
 
 of.options.SMOOTH_FPS=Smooth FPS
 of.options.SMOOTH_FPS.tooltip.1=Estabiliza a taxa de quadros ao equilibrar buffers da placa de vídeo.
-of.options.SMOOTH_FPS.tooltip.2=  Não - flutuação da taxa de quadros
-of.options.SMOOTH_FPS.tooltip.3=  Sim - estabilização da taxa de quadros
+of.options.SMOOTH_FPS.tooltip.2=  Não - taxa de quadros flutuante
+of.options.SMOOTH_FPS.tooltip.3=  Sim - taxa de quadros estável
 of.options.SMOOTH_FPS.tooltip.4=Esta opção depende da placa de vídeo
-of.options.SMOOTH_FPS.tooltip.5=e seu efeito nem sempre é visível.
+of.options.SMOOTH_FPS.tooltip.5=e seu efeito nem sempre é perceptível.
 
 of.options.SMOOTH_WORLD=Smooth World
 of.options.SMOOTH_WORLD.tooltip.1=Reduz a latência causada pelo servidor interno.
-of.options.SMOOTH_WORLD.tooltip.2=  Não - sem estabilização, a taxa de quadros pode flutuar
-of.options.SMOOTH_WORLD.tooltip.3=  Sim - estabilização da taxa de quadros
+of.options.SMOOTH_WORLD.tooltip.2=  Não - taxa de quadros flutuante
+of.options.SMOOTH_WORLD.tooltip.3=  Sim - taxa de quadros estável
 of.options.SMOOTH_WORLD.tooltip.4=Estabiliza a taxa de quadros ao particionar o carregamento interno do servidor.
 of.options.SMOOTH_WORLD.tooltip.5=Disponível apenas em mundos locais (Um jogador).
 
 of.options.FAST_RENDER=Render. Rápida
 of.options.FAST_RENDER.tooltip.1=Renderização Rápida
 of.options.FAST_RENDER.tooltip.2= Não - renderização normal (padrão)
-of.options.FAST_RENDER.tooltip.3= Sim - renderização otimizada (rápido)
+of.options.FAST_RENDER.tooltip.3= Sim - renderização otimizada (rápida)
 of.options.FAST_RENDER.tooltip.4=Utiliza um algoritmo especial de renderização que reduz
 of.options.FAST_RENDER.tooltip.5=o uso da GPU e eleva a taxa de quadros.
 
@@ -575,20 +575,20 @@ of.options.CHUNK_UPDATES_DYNAMIC.tooltip.4=Atualizações dinâmicas demandam ma
 of.options.CHUNK_UPDATES_DYNAMIC.tooltip.5=processamento para carregar o mundo rapidamente.
 
 of.options.LAZY_CHUNK_LOADING=Carreg. reduzido
-of.options.LAZY_CHUNK_LOADING.tooltip.1=Carregamento reduzido
+of.options.LAZY_CHUNK_LOADING.tooltip.1=Carregamento reduzido de chunks
 of.options.LAZY_CHUNK_LOADING.tooltip.2= Não - carregamento normal do servidor
 of.options.LAZY_CHUNK_LOADING.tooltip.3= Sim - carregamento reduzido (rápido)
-of.options.LAZY_CHUNK_LOADING.tooltip.4=Otimiza o carregamento de chunks do servidor,
-of.options.LAZY_CHUNK_LOADING.tooltip.5=distribuindo-os em ticks.
-of.options.LAZY_CHUNK_LOADING.tooltip.6=Desative-o se partes do mundo não carregarem corretamente.
+of.options.LAZY_CHUNK_LOADING.tooltip.4=Otimiza o carregamento de chunks do
+of.options.LAZY_CHUNK_LOADING.tooltip.5=servidor, distribuindo-os em ticks.
+of.options.LAZY_CHUNK_LOADING.tooltip.6=Desativar se partes do mundo não carregarem corretamente.
 of.options.LAZY_CHUNK_LOADING.tooltip.7=Disponível apenas em mundos locais (Um jogador).
 
 of.options.RENDER_REGIONS=Render. de regiões
 of.options.RENDER_REGIONS.tooltip.1=Renderização de regiões
 of.options.RENDER_REGIONS.tooltip.2= Não - (padrão) desativar renderização de regiões
 of.options.RENDER_REGIONS.tooltip.3= Sim - ativar renderização de regiões
-of.options.RENDER_REGIONS.tooltip.4=Quando ativada, renderiza terrenos distantes mais rapidamente.
-of.options.RENDER_REGIONS.tooltip.5=Ative o VBO para melhores resultados.
+of.options.RENDER_REGIONS.tooltip.4=Quando ativada, renderiza terrenos distantes mais
+of.options.RENDER_REGIONS.tooltip.5=rapidamente. Ative o VBO para melhores resultados.
 
 # Animations
 
@@ -628,10 +628,10 @@ of.options.LAGOMETER.tooltip.8=* Verde - Renderizar terreno
 
 of.options.PROFILER=Análise de depuração
 of.options.PROFILER.tooltip.1=Análise de depuração
-of.options.PROFILER.tooltip.2=  Sim - Depuração ativada, lento
-of.options.PROFILER.tooltip.3=  Não - Depuração desativada, rápido
-of.options.PROFILER.tooltip.4=A análise de depuração coleta e exibe dados de depuração
-of.options.PROFILER.tooltip.5=quando o referido modo é ativado (F3).
+of.options.PROFILER.tooltip.2=  Sim - Depuração ativada, lenta
+of.options.PROFILER.tooltip.3=  Não - Depuração desativada, rápida
+of.options.PROFILER.tooltip.4=A análise de depuração coleta e exibe dados de
+of.options.PROFILER.tooltip.5=depuração quando o referido modo é ativado (F3).
 
 of.options.WEATHER=Clima
 of.options.WEATHER.tooltip.1=Clima
@@ -648,29 +648,29 @@ of.options.TIME.tooltip.1=Tempo
 of.options.TIME.tooltip.2= Padrão - ciclos normais de dia/noite
 of.options.TIME.tooltip.3= Somente dia - somente dia
 of.options.TIME.tooltip.4= Somente noite - somente noite
-of.options.TIME.tooltip.5=Disponível apenas no modo Criativo e
-of.options.TIME.tooltip.6=em mundos locais (Um jogador)
+of.options.TIME.tooltip.5=Disponível apenas no modo Criativo e em mundos
+of.options.TIME.tooltip.6=locais (Um jogador)
 
 options.fullscreen.tooltip.1=Tela cheia
 options.fullscreen.tooltip.2=  Sim - jogar em tela cheia
 options.fullscreen.tooltip.3=  Não - abrir janela
-options.fullscreen.tooltip.4=O modo tela cheia pode ser mais lento do que o
-options.fullscreen.tooltip.5=de janela, dependendo da placa de vídeo.
+options.fullscreen.tooltip.4=O modo tela cheia pode ser mais lento do que o de
+options.fullscreen.tooltip.5=janela, dependendo da placa de vídeo.
 
-of.options.FULLSCREEN_MODE=Resolução da tela cheia
+of.options.FULLSCREEN_MODE=Resolução
 of.options.FULLSCREEN_MODE.tooltip.1=Resolução da tela cheia
 of.options.FULLSCREEN_MODE.tooltip.2=  Normal - resolução do monitor, lento
-of.options.FULLSCREEN_MODE.tooltip.3=  WxH - resolução personalizada, pode ser mais rápido
+of.options.FULLSCREEN_MODE.tooltip.3=  WxH - resolução personalizada, pode ser mais rápida
 of.options.FULLSCREEN_MODE.tooltip.4=A resolução escolhida será usada no modo de tela cheia (F11).
-of.options.FULLSCREEN_MODE.tooltip.5=Resoluções menores normalmente são rápidas.
+of.options.FULLSCREEN_MODE.tooltip.5=Resoluções menores normalmente são mais rápidas.
 
 of.options.SHOW_FPS=Exibir FPS
 of.options.SHOW_FPS.tooltip.1=Exibe a taxa concisa de quadros e informações de renderização.
 of.options.SHOW_FPS.tooltip.2=  C: - renderizadores de chunks
-of.options.SHOW_FPS.tooltip.3=  E: - entidades renderizadas + entidades de blocos
+of.options.SHOW_FPS.tooltip.3=  E: - entidades renderizadas + blocos-entidades
 of.options.SHOW_FPS.tooltip.4=  U: - atualizações de chunks
 of.options.SHOW_FPS.tooltip.5=A taxa concisa de quadros só é visível quando o
-of.options.SHOW_FPS.tooltip.6=o modo de depuração não está ativado.
+of.options.SHOW_FPS.tooltip.6=a tela de depuração não está ativada.
 
 of.options.save.default=Padrão (2s)
 of.options.save.20s=20s
@@ -679,12 +679,12 @@ of.options.save.30min=30min
 
 of.options.AUTOSAVE_TICKS=Autossalvamento
 of.options.AUTOSAVE_TICKS.tooltip.1=Intervalo do Autossalvamento
-of.options.AUTOSAVE_TICKS.tooltip.2=O intervalo padrão para o Autossalvamento (2s) NÃO É RECOMENDADO.
+of.options.AUTOSAVE_TICKS.tooltip.2=O intervalo padrão de Autossalvamento NÃO É RECOMENDADO.
 of.options.AUTOSAVE_TICKS.tooltip.3=O Autossalvamento pode causar o Lag Spike of Death.
 
-of.options.SCREENSHOT_SIZE=Tam. da captura de tela
+of.options.SCREENSHOT_SIZE=Captura de tela
 of.options.SCREENSHOT_SIZE.tooltip.1=Tamanho da captura de tela
-of.options.SCREENSHOT_SIZE.tooltip.2=  Padrão - tamanho padrão
+of.options.SCREENSHOT_SIZE.tooltip.2=  Padrão - tamanho comum
 of.options.SCREENSHOT_SIZE.tooltip.3=  2x-4x - tamanho personalizado
 of.options.SCREENSHOT_SIZE.tooltip.4=Tamanhos maiores requerem mais memória.
 of.options.SCREENSHOT_SIZE.tooltip.5=Incompatível com a Renderização Rápida e Antialiasing.


### PR DESCRIPTION
Noticed an error (my fault, sry) in strings containing only a `%` as showed below, and reviewed a number of strings to reduce overflows as well.

<img src=https://i.imgur.com/5VkNdzp.png>