### PR TITLE
Create en_ud.lang

### DIFF
--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
@@ -57,6 +57,16 @@ of.message.loadingVisibleChunks=sʞunɥɔ ǝꞁqᴉsᴉʌ ƃuᴉpɐo˥
 
 of.options.skinCustomisation.ofCape=˙˙˙ǝdɐƆ ǝuᴉℲᴉʇdo
 
+of.options.capeOF.title=ǝdɐƆ ǝuᴉℲᴉʇdo
+of.options.capeOF.openEditor=ɹoʇᴉpƎ ǝdɐƆ uǝdo
+of.options.capeOF.reloadCape=ǝdɐƆ pɐolǝᴚ
+
+of.message.capeOF.openEditor=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ uǝdo pꞁnoɥs ɹoʇᴉpǝ ǝdɐɔ ǝuᴉℲᴉʇdo ǝɥ⟘
+of.message.capeOF.reloadCape=˙spuoɔǝs ϛƖ uᴉ pǝpɐoꞁǝɹ ǝq ꞁꞁᴉʍ ǝdɐɔ ǝɥ⟘
+
+of.message.capeOF.error2=pǝꞁᴉɐɟ uoᴉʇɐɔᴉʇuǝɥʇnɐ ƃuɐɾoW.
+of.message.capeOF.error1=%s: ɹoɹɹƎ
+
 # Video settings
 
 options.graphics.tooltip.5=ʎʇᴉꞁɐnb ꞁɐnsᴉΛ

--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
@@ -1,0 +1,738 @@
+# Contributors of British English (upside down) #
+# DaDodger and sp614x for creating en_gb.lang
+# Regnander for converting and proofreading the result
+
+# General
+of.general.ambiguous=snonƃᴉqɯɐ
+of.general.compact=ʇɔɐdɯoƆ
+of.general.custom=ɯoʇsnƆ
+of.general.from=ɯoɹℲ
+of.general.id=pI
+of.general.max=ɯnɯᴉxɐW
+of.general.restart=ʇɹɐʇsǝɹ
+of.general.smart=ʇɹɐɯS
+
+# Keys
+of.key.zoom=ɯooZ
+
+# Message
+of.message.aa.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ƃuᴉsɐᴉꞁɐᴉʇu∀
+of.message.aa.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
+
+of.message.af.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀
+of.message.af.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
+
+of.message.fr.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɹǝpuǝɹ ʇsɐℲ
+of.message.fr.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
+
+of.message.an.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɥdʎꞁƃɐu∀ pƐ
+of.message.an.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
+
+of.message.shaders.aa2=˙ƃuᴉsɐᴉꞁɐᴉʇu∀ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.aa1=˙ǝɯɐƃ ǝɥʇ ʇɹɐʇsǝɹ puɐ ℲℲo oʇ ƃuᴉsɐᴉꞁɐᴉʇu∀ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
+
+of.message.shaders.af2=˙ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.af1=˙ℲℲo oʇ ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
+
+of.message.shaders.fr2=˙ɹǝpuǝɹ ʇsɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.fr1=˙ℲℲo oʇ ɹǝpuǝɹ ʇsɐℲ <- ǝɔuɐɯɹoɟɹǝԀ ʇǝs ǝsɐǝꞁԀ
+
+of.message.shaders.an2=˙ɥdʎꞁƃɐu∀ pƐ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.an1=˙ℲℲo oʇ ɥdʎꞁƃɐu∀ pƐ <- ɹǝɥʇo ʇǝs ǝsɐǝꞁԀ
+
+of.message.shaders.nv2=s% :uoᴉsɹǝʌ ǝuᴉℲᴉʇdo ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
+of.message.shaders.nv1=¿ǝnuᴉʇuoɔ oʇ ʇuɐʍ noʎ ǝɹns noʎ ǝɹ∀
+
+of.message.newVersion=§e%s§f :ǝꞁqɐꞁᴉɐʌɐ sᴉ uoᴉsɹǝʌ §eǝuᴉℲᴉʇdO§f ʍǝu ∀
+of.message.java64Bit=˙ǝɔuɐɯɹoɟɹǝd ǝsɐǝɹɔuᴉ oʇ §eɐʌɐſ ʇᴉq-߈9§f ꞁꞁɐʇsuᴉ uɐɔ no⅄
+of.message.openglError=(s%) s% :§eɹoɹɹƎ ˥פuǝdo§f
+
+of.message.shaders.loading=s% :sɹǝpɐɥs ƃuᴉpɐo˥
+
+of.message.other.reset=¿sǝnꞁɐʌ ʇꞁnɐɟǝp ɹᴉǝɥʇ oʇ sƃuᴉʇʇǝs oǝpᴉʌ ꞁꞁɐ ʇǝsǝᴚ
+
+of.message.loadingVisibleChunks=sʞunɥɔ ǝꞁqᴉsᴉʌ ƃuᴉpɐo˥
+
+# Skin customization
+
+of.options.skinCustomisation.ofCape=˙˙˙ǝdɐƆ ǝuᴉℲᴉʇdo
+
+# Video settings
+
+options.graphics.tooltip.5=ʎʇᴉꞁɐnb ꞁɐnsᴉΛ
+options.graphics.tooltip.4=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ -  ʇsɐℲ  
+options.graphics.tooltip.3=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥƃᴉɥ - ʎɔuɐℲ  
+options.graphics.tooltip.2='ɹǝʇɐʍ 'sǝʌɐǝꞁ 'spnoꞁɔ ɟo ǝɔuɐɹɐǝddɐ ǝɥʇ sǝƃuɐɥƆ
+options.graphics.tooltip.1=˙sǝpᴉs ssɐɹƃ puɐ sʍopɐɥs
+
+of.options.renderDistance.tiny=ʎuᴉ⟘
+of.options.renderDistance.short=ʇɹoɥS
+of.options.renderDistance.normal=ꞁɐɯɹoN
+of.options.renderDistance.far=ɹɐℲ
+of.options.renderDistance.extreme=ǝɯǝɹʇxƎ
+of.options.renderDistance.insane=ǝuɐsuI
+of.options.renderDistance.ludicrous=snoɹɔᴉpn˥
+
+options.renderDistance.tooltip.8=ǝɔuɐʇsᴉp ǝꞁqᴉsᴉΛ
+options.renderDistance.tooltip.7=(ʇsǝʇsɐɟ) ɯᘔƐ - ʎuᴉ⟘ ᘔ  
+options.renderDistance.tooltip.6=(ꞁɐɯɹou) ɯ8ᘔ⥝ - ꞁɐɯɹoN 8  
+options.renderDistance.tooltip.5=(ɹǝʍoꞁs) ɯ9ϛᘔ - ɹɐℲ 9⥝  
+options.renderDistance.tooltip.4=ƃuᴉpuɐɯǝp ǝɔɹnosǝɹ ʎɹǝʌ (¡ʇsǝʍoꞁs) ɯᘔ⥝ϛ - ǝɯǝɹʇxƎ ᘔƐ  
+options.renderDistance.tooltip.3=pǝʇɐɔoꞁꞁɐ W∀ɹ qפᘔ spǝǝu 'ɯ89ㄥ - ǝuɐsuI 8߈  
+options.renderDistance.tooltip.2=pǝʇɐɔoꞁꞁɐ W∀ɹ qפƐ spǝǝu 'ɯ߈ᘔ0⥝ - snoɹɔᴉpn˥ ߈9  
+options.renderDistance.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo ǝɹɐ ɹɐℲ 9⥝ ɹǝʌo sǝnꞁɐΛ
+
+options.ao.tooltip.4=ƃuᴉʇɥƃᴉꞁ ɥʇooɯS
+options.ao.tooltip.3=(ɹǝʇsɐɟ) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs ou - ℲℲo  
+options.ao.tooltip.2=(ɹǝʍoꞁs) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs ǝꞁdɯᴉs - ɯnɯᴉuᴉW  
+options.ao.tooltip.1=(ʇsǝʍoꞁs) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs xǝꞁdɯoɔ - ɯnɯᴉxɐW  
+
+options.framerateLimit.tooltip.6=ǝʇɐɹǝɯɐɹɟ xɐW
+options.framerateLimit.tooltip.5=(0ᘔ '0Ɛ '09) ǝʇɐɹǝɯɐɹɟ ɹoʇᴉuoɯ oʇ ʇᴉɯᴉꞁ - ɔuʎSΛ  
+options.framerateLimit.tooltip.4=ǝꞁqɐᴉɹɐʌ - ϛϛᘔ-ϛ  
+options.framerateLimit.tooltip.3=(ʇsǝʇsɐɟ) ʇᴉɯᴉꞁ ou - pǝʇᴉɯᴉꞁu∩  
+options.framerateLimit.tooltip.2=ɟᴉ uǝʌǝ SԀℲ ǝɥʇ sǝsɐǝɹɔǝp ʇᴉɯᴉꞁ ǝʇɐɹǝɯɐɹɟ ǝɥ⟘
+options.framerateLimit.tooltip.1=˙pǝɥɔɐǝɹ ʇou sᴉ ǝnꞁɐʌ ʇᴉɯᴉꞁ ǝɥʇ
+of.options.framerateLimit.vsync=ɔuʎSΛ
+
+of.options.AO_LEVEL=ꞁǝʌǝ˥ ƃuᴉʇɥƃᴉ˥ ɥʇooɯS
+of.options.AO_LEVEL.tooltip.4=ꞁǝʌǝꞁ ƃuᴉʇɥƃᴉꞁ ɥʇooɯS
+of.options.AO_LEVEL.tooltip.3=sʍopɐɥs ou - ℲℲo  
+of.options.AO_LEVEL.tooltip.2=sʍopɐɥs ʇɥƃᴉꞁ - %%0ϛ  
+of.options.AO_LEVEL.tooltip.1=sʍopɐɥs ʞɹɐp - %%00⥝  
+
+options.viewBobbing.tooltip.2=˙ʇuǝɯǝʌoɯ ɔᴉʇsᴉꞁɐǝɹ ǝɹoW
+options.viewBobbing.tooltip.1=˙sʇꞁnsǝɹ ʇsǝq ɹoɟ ℲℲo oʇ ʇᴉ ʇǝs sdɐɯdᴉɯ ƃuᴉsn uǝɥM
+
+options.guiScale.tooltip.6=ǝꞁɐɔS I∩פ
+options.guiScale.tooltip.5=ǝzᴉs ꞁɐɯᴉxɐɯ - oʇn∀  
+options.guiScale.tooltip.4=xƐ oʇ x⥝ - ǝƃɹɐ˥ 'ꞁɐɯɹoN 'ꞁꞁɐɯS  
+options.guiScale.tooltip.3=sʎɐꞁdsᴉp ʞ߈ uo ǝꞁqɐꞁᴉɐʌɐ - x0⥝ oʇ x߈  
+options.guiScale.tooltip.2=˙ǝpoɔᴉu∩ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ (˙˙˙ xϛ 'xƐ 'x⥝) sǝnꞁɐʌ ppo
+options.guiScale.tooltip.1=˙ɹǝʇsɐɟ ǝq ʎɐɯ I∩פ ɹǝꞁꞁɐɯs ∀
+
+options.vbo.tooltip.3=sʇɔǝɾqo ɹǝɟɟnq xǝʇɹǝΛ
+options.vbo.tooltip.2=ʎꞁꞁɐnsn sᴉ ɥɔᴉɥʍ ꞁǝpoɯ ƃuᴉɹǝpuǝɹ ǝʌᴉʇɐuɹǝʇꞁɐ uɐ sǝs∩
+options.vbo.tooltip.1=˙ƃuᴉɹǝpuǝɹ ʇꞁnɐɟǝp ǝɥʇ uɐɥʇ (%%0⥝-ϛ) ɹǝʇsɐɟ
+
+options.gamma.tooltip.6=˙sʇɔǝɾqo ɹǝʞɹɐp ɟo ssǝuʇɥƃᴉɹq ǝɥʇ sǝƃuɐɥƆ
+options.gamma.tooltip.5=ssǝuʇɥƃᴉɹq pɹɐpuɐʇs - ʎpooW  
+options.gamma.tooltip.4=ǝꞁqɐᴉɹɐʌ - %%66-⥝  
+options.gamma.tooltip.3=sʇɔǝɾqo ɹǝʞɹɐp ɹoɟ ssǝuʇɥƃᴉɹq ɯnɯᴉxɐɯ - ʇɥƃᴉɹq  
+options.gamma.tooltip.2= ɟo ssǝuʇɥƃᴉɹq ǝɥʇ ǝƃuɐɥɔ ʇou sǝop uoᴉʇdo sᴉɥ⟘
+options.gamma.tooltip.1=˙sʇɔǝɾqo ʞɔɐꞁq ʎꞁꞁnɟ
+
+options.anaglyph.tooltip.4=ɥdʎꞁƃɐu∀ pƐ
+options.anaglyph.tooltip.3=sɹnoꞁoɔ ʇuǝɹǝɟɟᴉp ƃuᴉsn ʇɔǝɟɟǝ pƐ ɔᴉdoɔsoǝɹǝʇs ɐ sǝꞁqɐuƎ
+options.anaglyph.tooltip.2=˙ǝʎǝ ɥɔɐǝ ɹoɟ
+options.anaglyph.tooltip.1=˙ƃuᴉʍǝᴉʌ ɹǝdoɹd ɹoɟ sǝssɐꞁƃ uɐʎɔ-pǝɹ sǝɹᴉnbǝᴚ
+
+of.options.ALTERNATE_BLOCKS=sʞɔoꞁq ǝʇɐuɹǝʇꞁ∀
+of.options.ALTERNATE_BLOCKS.tooltip.3=sʞɔoꞁq ǝʇɐuɹǝʇꞁ∀
+of.options.ALTERNATE_BLOCKS.tooltip.2=˙sʞɔoꞁq ǝɯos ɹoɟ sꞁǝpoɯ ʞɔoꞁq ǝʌᴉʇɐuɹǝʇꞁɐ sǝs∩
+of.options.ALTERNATE_BLOCKS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ pǝʇɔǝꞁǝs ǝɥʇ uo spuǝdǝp
+
+of.options.FOG_FANCY=ƃoℲ
+of.options.FOG_FANCY.tooltip.6=ǝdʎʇ ƃoℲ
+of.options.FOG_FANCY.tooltip.5=ƃoɟ ɹǝʇsɐɟ - ʇsɐℲ  
+of.options.FOG_FANCY.tooltip.4=ɹǝʇʇǝq sʞooꞁ 'ƃoɟ ɹǝʍoꞁs - ʎɔuɐℲ  
+of.options.FOG_FANCY.tooltip.3=ʇsǝʇsɐɟ 'ƃoɟ ou - ℲℲo  
+of.options.FOG_FANCY.tooltip.2= ǝɥʇ ʎq pǝʇɹoddns sᴉ ʇᴉ ɟᴉ ʎꞁuo ǝꞁqɐꞁᴉɐʌɐ sᴉ ƃoɟ ʎɔuɐɟ ǝɥ⟘
+of.options.FOG_FANCY.tooltip.1=˙pɹɐɔ ɔᴉɥdɐɹƃ
+
+of.options.FOG_START=ʇɹɐʇS ƃoℲ
+of.options.FOG_START.tooltip.4=ʇɹɐʇs ƃoℲ
+of.options.FOG_START.tooltip.3=ɹǝʎɐꞁd ǝɥʇ ɹɐǝu sʇɹɐʇs ƃoɟ ǝɥʇ - ᘔ˙0  
+of.options.FOG_START.tooltip.2=ɹǝʎɐꞁd ǝɥʇ ɯoɹɟ ɹɐɟ sʇɹɐʇs ƃoɟ ǝɥʇ - 8˙0  
+of.options.FOG_START.tooltip.1=˙ǝɔuɐɯɹoɟɹǝd ǝɥʇ ʇɔǝɟɟɐ ʇou sǝop ʎꞁꞁɐnsn uoᴉʇdo sᴉɥ⟘
+
+of.options.CHUNK_LOADING=ƃuᴉpɐo˥ ʞunɥƆ
+of.options.CHUNK_LOADING.tooltip.8=ƃuᴉpɐo˥ ʞunɥƆ
+of.options.CHUNK_LOADING.tooltip.7=sʞunɥɔ ƃuᴉpɐoꞁ uǝɥʍ SԀℲ ǝꞁqɐʇsun - ʇꞁnɐɟǝp  
+of.options.CHUNK_LOADING.tooltip.6=SԀℲ ǝꞁqɐʇs - ɥʇooɯS  
+of.options.CHUNK_LOADING.tooltip.5=ƃuᴉpɐoꞁ pꞁɹoʍ ɹǝʇsɐɟ xƐ 'SԀℲ ǝꞁqɐʇs - ǝɹoƆ-ᴉʇꞁnW  
+of.options.CHUNK_LOADING.tooltip.4= puɐ ƃuᴉɹǝʇʇnʇs ǝɥʇ ǝʌoɯǝɹ ǝɹoƆ-ᴉʇꞁnW puɐ ɥʇooɯS
+of.options.CHUNK_LOADING.tooltip.3=˙ƃuᴉpɐoꞁ ʞunɥɔ ʎq pǝsnɐɔ sǝzǝǝɹɟ
+of.options.CHUNK_LOADING.tooltip.2=puɐ ƃuᴉpɐoꞁ pꞁɹoʍ ǝɥʇ xƐ dn pǝǝds uɐɔ ǝɹoƆ-ᴉʇꞁnW
+of.options.CHUNK_LOADING.tooltip.1=˙ǝɹoɔ ∩ԀƆ puoɔǝs ɐ ƃuᴉsn ʎq SԀℲ ǝsɐǝɹɔuᴉ
+of.options.chunkLoading.smooth=ɥʇooɯS
+of.options.chunkLoading.multiCore=ǝɹoƆ-ᴉʇꞁnW
+
+of.options.shaders=˙˙˙sɹǝpɐɥS
+of.options.shadersTitle=sɹǝpɐɥS
+
+of.options.shaders.packNone=ℲℲo
+of.options.shaders.packDefault=(ꞁɐuɹǝʇuᴉ)
+
+of.options.shaders.ANTIALIASING=ƃuᴉsɐᴉꞁɐᴉʇu∀
+of.options.shaders.ANTIALIASING.tooltip.7=ƃuᴉsɐᴉꞁɐᴉʇu∀
+of.options.shaders.ANTIALIASING.tooltip.6=(ɹǝʇsɐɟ) ƃuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲo  
+of.options.shaders.ANTIALIASING.tooltip.5=(ɹǝʍoꞁs) sǝƃpǝ puɐ sǝuᴉꞁ pǝsɐᴉꞁɐᴉʇuɐ - x߈ 'xᘔ ∀∀XℲ  
+of.options.shaders.ANTIALIASING.tooltip.4=sɥʇooɯs ɥɔᴉɥʍ ʇɔǝɟɟǝ ƃuᴉssǝɔoɹd-ʇsod ɐ sᴉ ∀∀XℲ
+of.options.shaders.ANTIALIASING.tooltip.3=˙suoᴉʇᴉsuɐɹʇ ɹoꞁoɔ dɹɐɥs puɐ sǝuᴉꞁ pǝƃƃɐɾ
+of.options.shaders.ANTIALIASING.tooltip.2=ƃuᴉsɐᴉꞁɐᴉʇuɐ ꞁɐuoᴉʇᴉpɐɹʇ uɐɥʇ ɹǝʇsɐɟ sᴉ ʇI
+of.options.shaders.ANTIALIASING.tooltip.1=  ˙ɹǝpuǝɹ ʇsɐℲ puɐ sɹǝpɐɥs ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ sᴉ puɐ
+
+of.options.shaders.NORMAL_MAP=dɐW ꞁɐɯɹoN
+of.options.shaders.NORMAL_MAP.tooltip.7=dɐW ꞁɐɯɹoN
+of.options.shaders.NORMAL_MAP.tooltip.6= sdɐɯ ꞁɐɯɹou ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - No  
+of.options.shaders.NORMAL_MAP.tooltip.5=sdɐɯ ꞁɐɯɹou ǝꞁqɐsᴉp - ℲℲo  
+of.options.shaders.NORMAL_MAP.tooltip.4=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝq uɐɔ sdɐɯ ꞁɐɯɹoN
+of.options.shaders.NORMAL_MAP.tooltip.3=˙sǝɔɐɟɹns ꞁǝpoɯ ʇɐꞁɟ uo ʎɹʇǝɯoǝƃ pƐ ǝʇɐꞁnɯᴉs oʇ
+of.options.shaders.NORMAL_MAP.tooltip.2=ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ dɐɯ ꞁɐɯɹou ǝɥ⟘
+of.options.shaders.NORMAL_MAP.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ
+
+of.options.shaders.SPECULAR_MAP=dɐW ɹɐꞁnɔǝdS
+of.options.shaders.SPECULAR_MAP.tooltip.7=dɐW ɹɐꞁnɔǝdS
+of.options.shaders.SPECULAR_MAP.tooltip.6=sdɐɯ ɹɐꞁnɔǝds ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - No  
+of.options.shaders.SPECULAR_MAP.tooltip.5=sdɐɯ ɹɐꞁnɔǝds ǝꞁqɐsᴉp - ℲℲo  
+of.options.shaders.SPECULAR_MAP.tooltip.4=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝq uɐɔ sdɐɯ ɹɐꞁnɔǝdS
+of.options.shaders.SPECULAR_MAP.tooltip.3=˙sʇɔǝɟɟǝ uoᴉʇɔǝꞁɟǝɹ ꞁɐᴉɔǝds ǝʇɐꞁnɯᴉs oʇ
+of.options.shaders.SPECULAR_MAP.tooltip.2=ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ dɐɯ ɹɐꞁnɔǝds ǝɥ⟘
+of.options.shaders.SPECULAR_MAP.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ
+
+of.options.shaders.RENDER_RES_MUL=ʎʇᴉꞁɐnQ ɹǝpuǝᴚ
+of.options.shaders.RENDER_RES_MUL.tooltip.8=ʎʇᴉꞁɐnQ ɹǝpuǝᴚ
+of.options.shaders.RENDER_RES_MUL.tooltip.7=(ʇsǝʇsɐɟ) ʍoꞁ - xϛ˙0  
+of.options.shaders.RENDER_RES_MUL.tooltip.6=(ʇꞁnɐɟǝp) pɹɐpuɐʇs - x⥝  
+of.options.shaders.RENDER_RES_MUL.tooltip.5=(ʇsǝʍoꞁs) ɥƃᴉɥ - xᘔ  
+of.options.shaders.RENDER_RES_MUL.tooltip.4= ǝɹnʇxǝʇ ǝɥʇ ɟo ǝzᴉs ǝɥʇ sꞁoɹʇuoɔ ʎʇᴉꞁɐnb ɹǝpuǝᴚ
+of.options.shaders.RENDER_RES_MUL.tooltip.3=˙oʇ ƃuᴉɹǝpuǝɹ sᴉ ʞɔɐd ɹǝpɐɥs ǝɥʇ ʇɐɥʇ
+of.options.shaders.RENDER_RES_MUL.tooltip.2=˙sʎɐꞁdsᴉp ʞ߈ ɥʇᴉʍ ꞁnɟǝsn ǝq uɐɔ sǝnꞁɐʌ ɹǝʍo˥
+of.options.shaders.RENDER_RES_MUL.tooltip.1=˙ɹǝʇꞁᴉɟ ƃuᴉsɐᴉꞁɐᴉʇuɐ uɐ sɐ ʞɹoʍ sǝnꞁɐʌ ɹǝɥƃᴉH
+
+of.options.shaders.SHADOW_RES_MUL=ʎʇᴉꞁɐnQ ʍopɐɥS
+of.options.shaders.SHADOW_RES_MUL.tooltip.8=ʎʇᴉꞁɐnQ ʍopɐɥS
+of.options.shaders.SHADOW_RES_MUL.tooltip.7=(ʇsǝʇsɐɟ) ʍoꞁ - xϛ˙0  
+of.options.shaders.SHADOW_RES_MUL.tooltip.6=(ʇꞁnɐɟǝp) pɹɐpuɐʇs - x⥝  
+of.options.shaders.SHADOW_RES_MUL.tooltip.5=(ʇsǝʍoꞁs) ɥƃᴉɥ - xᘔ  
+of.options.shaders.SHADOW_RES_MUL.tooltip.4=dɐɯ ʍopɐɥs ǝɥʇ ɟo ǝzᴉs ǝɥʇ sꞁoɹʇuoɔ ʎʇᴉꞁɐnb ʍopɐɥS
+of.options.shaders.SHADOW_RES_MUL.tooltip.3=˙ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝɹnʇxǝʇ
+of.options.shaders.SHADOW_RES_MUL.tooltip.2= sǝnꞁɐʌ ɹǝʍo˥
+of.options.shaders.SHADOW_RES_MUL.tooltip.1= sǝnꞁɐʌ ɹǝɥƃᴉH
+
+of.options.shaders.HAND_DEPTH_MUL=ɥʇdǝp puɐH
+of.options.shaders.HAND_DEPTH_MUL.tooltip.8=ɥʇdǝp puɐH
+of.options.shaders.HAND_DEPTH_MUL.tooltip.7=ɐɹǝɯɐɔ ǝɥʇ oʇ ɹɐǝu puɐɥ - xϛ˙0  
+of.options.shaders.HAND_DEPTH_MUL.tooltip.6=(ʇꞁnɐɟǝp) - x⥝  
+of.options.shaders.HAND_DEPTH_MUL.tooltip.5=ɐɹǝɯɐɔ ǝɥʇ ɯoɹɟ ɹɐɟ puɐɥ - xᘔ  
+of.options.shaders.HAND_DEPTH_MUL.tooltip.4=ǝɹɐ sʇɔǝɾqo pꞁǝɥpuɐɥ ǝɥʇ ɹɐɟ ʍoɥ sꞁoɹʇuoɔ ɥʇdǝp puɐH
+of.options.shaders.HAND_DEPTH_MUL.tooltip.3=˙ɐɹǝɯɐɔ ǝɥʇ ɯoɹɟ
+of.options.shaders.HAND_DEPTH_MUL.tooltip.2=ǝƃuɐɥɔ pꞁnoɥs sᴉɥʇ ɹnꞁq ɥʇdǝp ƃuᴉsn sʞɔɐd ɹǝpɐɥs ɹoℲ
+of.options.shaders.HAND_DEPTH_MUL.tooltip.1=˙sʇɔǝɾqo pꞁǝɥpuɐɥ ɟo ƃuᴉɹɹnꞁq ǝɥʇ
+
+of.options.shaders.CLOUD_SHADOW=ʍopɐɥS pnoꞁƆ
+
+of.options.shaders.OLD_HAND_LIGHT=ʇɥƃᴉ˥ puɐH pꞁo
+of.options.shaders.OLD_HAND_LIGHT.tooltip.7=ʇɥƃᴉ˥ puɐH pꞁo
+of.options.shaders.OLD_HAND_LIGHT.tooltip.6=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝp  
+of.options.shaders.OLD_HAND_LIGHT.tooltip.5=ʇɥƃᴉꞁpuɐɥ pꞁo ǝsn - No  
+of.options.shaders.OLD_HAND_LIGHT.tooltip.4=ʇɥƃᴉꞁpuɐɥ ʍǝu ǝsn - ℲℲo  
+of.options.shaders.OLD_HAND_LIGHT.tooltip.3=  ʎꞁuo ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥs sʍoꞁꞁɐ ʇɥƃᴉꞁ puɐɥ pꞁo
+of.options.shaders.OLD_HAND_LIGHT.tooltip.2= puɐɥ uᴉɐɯ ǝɥʇ uᴉ sɯǝʇᴉ ƃuᴉʇʇᴉɯǝ ʇɥƃᴉꞁ ǝsᴉuƃoɔǝɹ
+of.options.shaders.OLD_HAND_LIGHT.tooltip.1=˙puɐɥ-ɟɟo ǝɥʇ uᴉ sɯǝʇᴉ ɥʇᴉʍ ʞɹoʍ osꞁɐ oʇ
+
+of.options.shaders.OLD_LIGHTING=ƃuᴉʇɥƃᴉ˥ pꞁo
+of.options.shaders.OLD_LIGHTING.tooltip.8=ƃuᴉʇɥƃᴉ˥ pꞁo
+of.options.shaders.OLD_LIGHTING.tooltip.7=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝp  
+of.options.shaders.OLD_LIGHTING.tooltip.6=ƃuᴉʇɥƃᴉꞁ pꞁo ǝsn - No  
+of.options.shaders.OLD_LIGHTING.tooltip.5=ƃuᴉʇɥƃᴉꞁ pꞁo ǝsn ʇou op - ℲℲo  
+of.options.shaders.OLD_LIGHTING.tooltip.4= pǝᴉꞁddɐ ƃuᴉʇɥƃᴉꞁ pǝxᴉɟ ǝɥʇ sꞁoɹʇuoɔ ƃuᴉʇɥƃᴉꞁ pꞁo
+of.options.shaders.OLD_LIGHTING.tooltip.3= ˙sǝpᴉs ʞɔoꞁq ǝɥʇ oʇ ɐꞁꞁᴉuɐʌ ʎq
+of.options.shaders.OLD_LIGHTING.tooltip.2= ǝpᴉʌoɹd ʎꞁꞁɐnsn sʍopɐɥs ǝsn ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥS
+of.options.shaders.OLD_LIGHTING.tooltip.1=˙uoᴉʇᴉsod uns ǝɥʇ uo ƃuᴉpuǝdǝp ƃuᴉʇɥƃᴉꞁ ɹǝʇʇǝq ɥɔnɯ
+
+of.options.shaders.DOWNLOAD=sɹǝpɐɥS pɐoꞁuʍop
+of.options.shaders.DOWNLOAD.tooltip.5=sɹǝpɐɥS pɐoꞁuʍop
+of.options.shaders.DOWNLOAD.tooltip.4= 
+of.options.shaders.DOWNLOAD.tooltip.3=˙ɹǝsʍoɹq ɐ uᴉ ǝƃɐd sʞɔɐd ɹǝpɐɥs ǝɥʇ suǝdo
+of.options.shaders.DOWNLOAD.tooltip.2=,,ɹǝpꞁoℲ sɹǝpɐɥS,, ǝɥʇ uᴉ sʞɔɐd ɹǝpɐɥs pǝpɐoꞁuʍop ǝɥʇ ʇnԀ
+of.options.shaders.DOWNLOAD.tooltip.1=˙sɹǝpɐɥs pǝꞁꞁɐʇsuᴉ ɟo ʇsᴉꞁ ǝɥʇ uᴉ ɹɐǝddɐ ꞁꞁᴉʍ ʎǝɥʇ puɐ
+
+of.options.shaders.SHADER_PACK=ʞɔɐԀ ɹǝpɐɥS
+
+of.options.shaders.shadersFolder=ɹǝpꞁoℲ sɹǝpɐɥS
+of.options.shaders.shaderOptions=˙˙˙suoᴉʇdo ɹǝpɐɥS
+
+of.options.shaderOptionsTitle=suoᴉʇdo ɹǝpɐɥS
+
+of.options.quality=˙˙˙ʎʇᴉꞁɐnQ
+of.options.qualityTitle=sƃuᴉʇʇǝS ʎʇᴉꞁɐnQ
+
+of.options.details=˙˙˙sꞁᴉɐʇǝp
+of.options.detailsTitle=sƃuᴉʇʇǝS ꞁᴉɐʇǝp
+
+of.options.performance=˙˙˙ǝɔuɐɯɹoɟɹǝԀ
+of.options.performanceTitle=sƃuᴉʇʇǝS ǝɔuɐɯɹoɟɹǝԀ
+
+of.options.animations=˙˙˙suoᴉʇɐɯᴉu∀
+of.options.animationsTitle=sƃuᴉʇʇǝS uoᴉʇɐɯᴉu∀
+
+of.options.other=˙˙˙ɹǝɥʇo
+of.options.otherTitle=sƃuᴉʇʇǝS ɹǝɥʇo
+
+of.options.other.reset=˙˙˙sƃuᴉʇʇǝS oǝpᴉΛ ʇǝsǝᴚ
+
+of.shaders.profile=ǝꞁᴉɟoɹԀ
+
+# Quality
+
+of.options.mipmap.bilinear=ɹɐǝuᴉꞁᴉᗺ
+of.options.mipmap.linear=ɹɐǝuᴉ˥
+of.options.mipmap.nearest=ʇsǝɹɐǝN
+of.options.mipmap.trilinear=ɹɐǝuᴉꞁᴉɹ⟘
+
+options.mipmapLevels.tooltip.6=ɹǝʇʇǝq ʞooꞁ sʇɔǝɾqo ʇuɐʇsᴉp sǝʞɐɯ ɥɔᴉɥʍ ʇɔǝɟɟǝ ꞁɐnsᴉΛ
+options.mipmapLevels.tooltip.5=sꞁᴉɐʇǝp ǝɹnʇxǝʇ ǝɥʇ ƃuᴉɥʇooɯs ʎq
+options.mipmapLevels.tooltip.4=ƃuᴉɥʇooɯs ou - ℲℲo  
+options.mipmapLevels.tooltip.3=ƃuᴉɥʇooɯs ɯnɯᴉuᴉɯ - ⥝  
+options.mipmapLevels.tooltip.2=ƃuᴉɥʇooɯs ɯnɯᴉxɐɯ - ɯnɯᴉxɐW  
+options.mipmapLevels.tooltip.1=˙ǝɔuɐɯɹoɟɹǝd ǝɥʇ ʇɔǝɟɟɐ ʇou sǝop ʎꞁꞁɐnsn uoᴉʇdo sᴉɥ⟘
+
+of.options.MIPMAP_TYPE=ǝdʎ⟘ dɐɯdᴉW
+of.options.MIPMAP_TYPE.tooltip.6=ɹǝʇʇǝq ʞooꞁ sʇɔǝɾqo ʇuɐʇsᴉp sǝʞɐɯ ɥɔᴉɥʍ ʇɔǝɟɟǝ ꞁɐnsᴉΛ
+of.options.MIPMAP_TYPE.tooltip.5=sꞁᴉɐʇǝp ǝɹnʇxǝʇ ǝɥʇ ƃuᴉɥʇooɯs ʎq
+of.options.MIPMAP_TYPE.tooltip.4=(ʇsǝʇsɐɟ) ƃuᴉɥʇooɯs ɥƃnoɹ - ʇsǝɹɐǝN  
+of.options.MIPMAP_TYPE.tooltip.3=ƃuᴉɥʇooɯs ꞁɐɯɹou - ɹɐǝuᴉ˥  
+of.options.MIPMAP_TYPE.tooltip.2=ƃuᴉɥʇooɯs ǝuᴉɟ - ɹɐǝuᴉꞁᴉq  
+of.options.MIPMAP_TYPE.tooltip.1=(ʇsǝʍoꞁs) ƃuᴉɥʇooɯs ʇsǝuᴉɟ - ɹɐǝuᴉꞁᴉɹ⟘  
+
+
+of.options.AA_LEVEL=ƃuᴉsɐᴉꞁɐᴉʇu∀
+of.options.AA_LEVEL.tooltip.8=ƃuᴉsɐᴉꞁɐᴉʇu∀
+of.options.AA_LEVEL.tooltip.7=(ɹǝʇsɐɟ) ƃuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲo 
+of.options.AA_LEVEL.tooltip.6=(ɹǝʍoꞁs) sǝƃpǝ puɐ sǝuᴉꞁ pǝsɐᴉꞁɐᴉʇuɐ - 9⥝-ᘔ 
+of.options.AA_LEVEL.tooltip.5= puɐ sǝuᴉꞁ pǝƃƃɐɾ sɥʇooɯs ƃuᴉsɐᴉꞁɐᴉʇu∀ ǝɥ⟘
+of.options.AA_LEVEL.tooltip.4=˙suoᴉʇᴉsuɐɹʇ ɹnoꞁoɔ dɹɐɥs
+of.options.AA_LEVEL.tooltip.3=˙SԀℲ ǝɥʇ ǝsɐǝɹɔǝp ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ ʇᴉ pǝꞁqɐuǝ uǝɥM
+of.options.AA_LEVEL.tooltip.2=˙spɹɐɔ sɔᴉɥdɐɹƃ ꞁꞁɐ ʎq pǝʇɹoddns ǝɹɐ sꞁǝʌǝꞁ ꞁꞁɐ ʇoN
+of.options.AA_LEVEL.tooltip.1=¡⟘ɹ∀⟘SƎɹ ɐ ɹǝʇɟɐ ǝʌᴉʇɔǝɟɟƎ
+
+of.options.AF_LEVEL=ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀
+of.options.AF_LEVEL.tooltip.6=ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀
+of.options.AF_LEVEL.tooltip.5=(ɹǝʇsɐɟ) ꞁᴉɐʇǝp ǝɹnʇxǝʇ pɹɐpuɐʇs (ʇꞁnɐɟǝp) - ℲℲo 
+of.options.AF_LEVEL.tooltip.4=(ɹǝʍoꞁs) sǝɹnʇxǝʇ pǝddɐɯdᴉɯ uᴉ sꞁᴉɐʇǝp ɹǝuᴉɟ - 9⥝-ᘔ 
+of.options.AF_LEVEL.tooltip.3=uᴉ sꞁᴉɐʇǝp sǝɹoʇsǝɹ ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ ǝɥ⟘
+of.options.AF_LEVEL.tooltip.2=˙sǝɹnʇxǝʇ pǝddɐɯdᴉɯ
+of.options.AF_LEVEL.tooltip.1=˙SԀℲ ǝɥʇ ǝsɐǝɹɔǝp ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ ʇᴉ pǝꞁqɐuǝ uǝɥM
+
+of.options.CLEAR_WATER=ɹǝʇɐM ɹɐǝꞁƆ
+of.options.CLEAR_WATER.tooltip.3=ɹǝʇɐM ɹɐǝꞁƆ
+of.options.CLEAR_WATER.tooltip.2=ɹǝʇɐʍ ʇuǝɹɐdsuɐɹʇ 'ɹɐǝꞁɔ - No  
+of.options.CLEAR_WATER.tooltip.1=ɹǝʇɐʍ ʇꞁnɐɟǝp - ℲℲo  
+
+of.options.RANDOM_ENTITIES=sǝᴉʇᴉʇuƎ ɯopuɐᴚ
+of.options.RANDOM_ENTITIES.tooltip.5=sǝᴉʇᴉʇuƎ ɯopuɐᴚ
+of.options.RANDOM_ENTITIES.tooltip.4=ɹǝʇsɐɟ 'sǝᴉʇᴉʇuǝ ɯopuɐɹ ou - ℲℲo  
+of.options.RANDOM_ENTITIES.tooltip.3=ɹǝʍoꞁs 'sǝᴉʇᴉʇuǝ ɯopuɐɹ - No  
+of.options.RANDOM_ENTITIES.tooltip.2=˙sǝᴉʇᴉʇuǝ ǝɯɐƃ ǝɥʇ ɹoɟ sǝɹnʇxǝʇ ɯopuɐɹ sǝsn sǝᴉʇᴉʇuǝ ɯopuɐᴚ
+of.options.RANDOM_ENTITIES.tooltip.1=˙sǝɹnʇxǝʇ ʎʇᴉʇuǝ ǝꞁdᴉʇꞁnɯ sɐɥ ɥɔᴉɥʍ ʞɔɐd ǝɔɹnosǝɹ ɐ spǝǝu ʇI
+
+of.options.BETTER_GRASS=ssɐɹפ ɹǝʇʇǝᗺ
+of.options.BETTER_GRASS.tooltip.4=ssɐɹפ ɹǝʇʇǝᗺ
+of.options.BETTER_GRASS.tooltip.3=ʇsǝʇsɐɟ 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ʇꞁnɐɟǝp - ℲℲo  
+of.options.BETTER_GRASS.tooltip.2=ɹǝʍoꞁs 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ꞁꞁnɟ - ʇsɐℲ  
+of.options.BETTER_GRASS.tooltip.1=ʇsǝʍoꞁs 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ɔᴉɯɐuʎp - ʎɔuɐℲ  
+
+of.options.BETTER_SNOW=ʍouS ɹǝʇʇǝᗺ
+of.options.BETTER_SNOW.tooltip.5=ʍouS ɹǝʇʇǝᗺ
+of.options.BETTER_SNOW.tooltip.4=ɹǝʇsɐɟ 'ʍous ʇꞁnɐɟǝp - ℲℲo  
+of.options.BETTER_SNOW.tooltip.3=ɹǝʍoꞁs 'ʍous ɹǝʇʇǝq - No  
+of.options.BETTER_SNOW.tooltip.2=(ssɐɹƃ ꞁꞁɐʇ 'ǝɔuǝɟ) sʞɔoꞁq ʇuǝɹɐdsuɐɹʇ ɹǝpun ʍous sʍoɥS
+of.options.BETTER_SNOW.tooltip.1=˙sʞɔoꞁq ʍous ɥʇᴉʍ ƃuᴉɹǝpɹoq uǝɥʍ
+
+of.options.CUSTOM_FONTS=sʇuoℲ ɯoʇsnƆ
+of.options.CUSTOM_FONTS.tooltip.5=sʇuoℲ ɯoʇsnƆ
+of.options.CUSTOM_FONTS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sʇuoɟ ɯoʇsnɔ sǝsn - No  
+of.options.CUSTOM_FONTS.tooltip.3=ɹǝʇsɐɟ 'ʇuoɟ ʇꞁnɐɟǝp sǝsn - ℲℲo  
+of.options.CUSTOM_FONTS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sʇuoɟ ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_FONTS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
+
+of.options.CUSTOM_COLORS=sɹnoꞁoƆ ɯoʇsnƆ
+of.options.CUSTOM_COLORS.tooltip.5=sɹnoꞁoƆ ɯoʇsnƆ
+of.options.CUSTOM_COLORS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ ɯoʇsnɔ sǝsn - No  
+of.options.CUSTOM_COLORS.tooltip.3=ɹǝʇsɐɟ ' sɹnoꞁoɔ ʇꞁnɐɟǝp sǝsn - ℲℲo  
+of.options.CUSTOM_COLORS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ  sɹnoꞁoɔ ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_COLORS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
+
+of.options.SWAMP_COLORS=sɹnoꞁoƆ dɯɐʍS
+of.options.SWAMP_COLORS.tooltip.4=sɹnoꞁoƆ dɯɐʍS
+of.options.SWAMP_COLORS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ dɯɐʍs ǝsn - No  
+of.options.SWAMP_COLORS.tooltip.2=ɹǝʇsɐɟ 'sɹnoꞁoɔ dɯɐʍs ǝsn ʇou op - ℲℲo  
+of.options.SWAMP_COLORS.tooltip.1=˙ɹǝʇɐʍ puɐ sǝuᴉʌ 'sǝʌɐǝꞁ 'ssɐɹƃ ʇɔǝɟɟɐ sɹnoꞁoɔ dɯɐʍs ǝɥ⟘
+
+of.options.SMOOTH_BIOMES=sǝɯoᴉq ɥʇooɯS
+of.options.SMOOTH_BIOMES.tooltip.6=sǝɯoᴉq ɥʇooɯS
+of.options.SMOOTH_BIOMES.tooltip.5=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs - No  
+of.options.SMOOTH_BIOMES.tooltip.4=ɹǝʇsɐɟ 'sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs ou - ℲℲo  
+of.options.SMOOTH_BIOMES.tooltip.3=puɐ ƃuᴉꞁdɯɐs ʎq ǝuop sᴉ sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs ǝɥ⟘
+of.options.SMOOTH_BIOMES.tooltip.2=˙sʞɔoꞁq ƃuᴉpunoɹɹns ꞁꞁɐ ɟo ɹnoꞁoɔ ǝɥʇ ƃuᴉƃɐɹǝʌɐ
+of.options.SMOOTH_BIOMES.tooltip.1=˙ɹǝʇɐʍ puɐ sǝuᴉʌ 'sǝʌɐǝꞁ 'ssɐɹƃ ǝɹɐ pǝʇɔǝɟɟ∀
+
+of.options.CONNECTED_TEXTURES=sǝɹnʇxǝ⟘ pǝʇɔǝuuoƆ
+of.options.CONNECTED_TEXTURES.tooltip.8=sǝɹnʇxǝ⟘ pǝʇɔǝuuoƆ
+of.options.CONNECTED_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ou - ℲℲo  
+of.options.CONNECTED_TEXTURES.tooltip.6=sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ʇsɐɟ - ʇsɐℲ  
+of.options.CONNECTED_TEXTURES.tooltip.5=sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ʎɔuɐɟ - ʎɔuɐℲ  
+of.options.CONNECTED_TEXTURES.tooltip.4='ssɐꞁƃ ɟo sǝɹnʇxǝʇ ǝɥʇ suᴉoɾ sǝɹnʇxǝʇ pǝʇɔǝuuoƆ
+of.options.CONNECTED_TEXTURES.tooltip.3=oʇ ʇxǝu pǝɔɐꞁd uǝɥʍ sǝʌꞁǝɥsʞooq puɐ ǝuoʇspuɐs
+of.options.CONNECTED_TEXTURES.tooltip.2=pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ǝɥ⟘ ˙ɹǝɥʇo ɥɔɐǝ
+of.options.CONNECTED_TEXTURES.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥʇ ʎq
+
+of.options.NATURAL_TEXTURES=sǝɹnʇxǝ⟘ ꞁɐɹnʇɐN
+of.options.NATURAL_TEXTURES.tooltip.8=sǝɹnʇxǝ⟘ ꞁɐɹnʇɐN
+of.options.NATURAL_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ꞁɐɹnʇɐu ou - ℲℲo  
+of.options.NATURAL_TEXTURES.tooltip.6=sǝɹnʇxǝʇ ꞁɐɹnʇɐu ǝsn - No  
+of.options.NATURAL_TEXTURES.tooltip.5=uɹǝʇʇɐd ǝʞᴉꞁpᴉɹƃ ǝɥʇ ǝʌoɯǝɹ sǝɹnʇxǝʇ ꞁɐɹnʇɐN
+of.options.NATURAL_TEXTURES.tooltip.4=˙ǝdʎʇ ǝɯɐs ǝɥʇ ɟo sʞɔoꞁq ƃuᴉʇɐǝdǝɹ ʎq pǝʇɐǝɹɔ
+of.options.NATURAL_TEXTURES.tooltip.3=ǝsɐq ǝɥʇ ɟo sʇuɐᴉɹɐʌ pǝddᴉꞁɟ puɐ pǝʇɐʇoɹ sǝsn ʇI
+of.options.NATURAL_TEXTURES.tooltip.2=ꞁɐɹnʇɐu ǝɥʇ ɹoɟ uoᴉʇɐɹnƃᴉɟuoɔ ǝɥ⟘ ˙ǝɹnʇxǝʇ ʞɔoꞁq
+of.options.NATURAL_TEXTURES.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns sᴉ sǝɹnʇxǝʇ
+
+of.options.EMISSIVE_TEXTURES=sǝɹnʇxǝ⟘ ǝʌᴉssᴉɯƎ
+of.options.EMISSIVE_TEXTURES.tooltip.8=sǝɹnʇxǝ⟘ ǝʌᴉssᴉɯƎ
+of.options.EMISSIVE_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ou - ℲℲo  
+of.options.EMISSIVE_TEXTURES.tooltip.6=sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ǝsn - No  
+of.options.EMISSIVE_TEXTURES.tooltip.5=sʎɐꞁɹǝʌo sɐ pǝɹǝpuǝɹ ǝɹɐ sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ǝɥ⟘
+of.options.EMISSIVE_TEXTURES.tooltip.4=ǝʇɐꞁnɯᴉs oʇ pǝsn ǝq uɐɔ ʎǝɥ⟘ ˙ssǝuʇɥƃᴉɹq ꞁꞁnɟ ɥʇᴉʍ
+of.options.EMISSIVE_TEXTURES.tooltip.3=˙ǝɹnʇxǝʇ ǝsɐq ǝɥʇ ɟo sʇɹɐd ƃuᴉʇʇᴉɯǝ ʇɥƃᴉꞁ
+of.options.EMISSIVE_TEXTURES.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ǝɥ⟘
+of.options.EMISSIVE_TEXTURES.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
+
+of.options.CUSTOM_SKY=ʎʞS ɯoʇsnƆ
+of.options.CUSTOM_SKY.tooltip.5=ʎʞS ɯoʇsnƆ
+of.options.CUSTOM_SKY.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ʎʞs ɯoʇsnɔ - No  
+of.options.CUSTOM_SKY.tooltip.3=ɹǝʇsɐɟ 'ʎʞs ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_SKY.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ ʎʞs ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_SKY.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
+
+of.options.CUSTOM_ITEMS=sɯǝʇI ɯoʇsnƆ
+of.options.CUSTOM_ITEMS.tooltip.5=sɯǝʇI ɯoʇsnƆ
+of.options.CUSTOM_ITEMS.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ɯǝʇᴉ ɯoʇsnɔ - No  
+of.options.CUSTOM_ITEMS.tooltip.3=ɹǝʇsɐɟ 'sǝɹnʇxǝʇ ɯǝʇᴉ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_ITEMS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ ɯǝʇᴉ ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_ITEMS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
+
+of.options.CUSTOM_ENTITY_MODELS=sꞁǝpoW ʎʇᴉʇuƎ ɯoʇsnƆ
+of.options.CUSTOM_ENTITY_MODELS.tooltip.5=sꞁǝpoW ʎʇᴉʇuƎ ɯoʇsnƆ
+of.options.CUSTOM_ENTITY_MODELS.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sꞁǝpoɯ ʎʇᴉʇuǝ ɯoʇsnɔ - No  
+of.options.CUSTOM_ENTITY_MODELS.tooltip.3=ɹǝʇsɐɟ 'sꞁǝpoɯ ʎʇᴉʇuǝ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_ENTITY_MODELS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sꞁǝpoɯ ʎʇᴉʇuǝ ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_ENTITY_MODELS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
+
+of.options.CUSTOM_GUIS=sI∩פ ɯoʇsnƆ
+of.options.CUSTOM_GUIS.tooltip.4=sI∩פ ɯoʇsnƆ
+of.options.CUSTOM_GUIS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sI∩פ ɯoʇsnɔ - No  
+of.options.CUSTOM_GUIS.tooltip.2=ɹǝʇsɐɟ 'sI∩פ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_GUIS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sI∩פ ɯoʇsnɔ ǝɥ⟘
+
+# Details
+
+of.options.CLOUDS=spnoꞁƆ
+of.options.CLOUDS.tooltip.7=spnoꞁƆ
+of.options.CLOUDS.tooltip.6=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.CLOUDS.tooltip.5=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ - ʇsɐℲ  
+of.options.CLOUDS.tooltip.4=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥƃᴉɥ - ʎɔuɐℲ  
+of.options.CLOUDS.tooltip.3=ʇsǝʇsɐɟ 'spnoꞁɔ ou - ℲℲo  
+of.options.CLOUDS.tooltip.2=˙pᘔ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʇsɐℲ
+of.options.CLOUDS.tooltip.1=˙pƐ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʎɔuɐℲ
+
+of.options.CLOUD_HEIGHT=ʇɥƃᴉǝH pnoꞁƆ
+of.options.CLOUD_HEIGHT.tooltip.3=ʇɥƃᴉǝH pnoꞁƆ
+of.options.CLOUD_HEIGHT.tooltip.2=ʇɥƃᴉǝɥ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CLOUD_HEIGHT.tooltip.1=ʇᴉɯᴉꞁ ʇɥƃᴉǝɥ pꞁɹoʍ ǝʌoqɐ - %%00⥝  
+
+of.options.TREES=sǝǝɹ⟘
+of.options.TREES.tooltip.7=sǝǝɹ⟘
+of.options.TREES.tooltip.6=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.TREES.tooltip.5=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ - ʇsɐℲ  
+of.options.TREES.tooltip.4=ʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝɥƃᴉɥ - ʇɹɐɯS  
+of.options.TREES.tooltip.3=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ʇsǝɥƃᴉɥ - ʎɔuɐℲ  
+of.options.TREES.tooltip.2=˙sǝʌɐǝꞁ ǝnbɐdo ǝʌɐɥ sǝǝɹʇ ʇsɐℲ
+of.options.TREES.tooltip.1=˙sǝʌɐǝꞁ ʇuǝɹɐdsuɐɹʇ ǝʌɐɥ sǝǝɹʇ ʇɹɐɯs puɐ ʎɔuɐℲ
+
+of.options.RAIN=ʍouS ⅋ uᴉɐᴚ
+of.options.RAIN.tooltip.7=ʍouS ⅋ uᴉɐᴚ
+of.options.RAIN.tooltip.6=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.RAIN.tooltip.5=ɹǝʇsɐɟ 'ʍous/uᴉɐɹ ʇɥƃᴉꞁ -  ʇsɐℲ  
+of.options.RAIN.tooltip.4=ɹǝʍoꞁs 'ʍous/uᴉɐɹ ʎʌɐǝɥ - ʎɔuɐℲ  
+of.options.RAIN.tooltip.3=ʇsǝʇsɐɟ 'ʍous/uᴉɐɹ ou - ℲℲo  
+of.options.RAIN.tooltip.2=spunos uᴉɐɹ puɐ sǝɥsɐꞁds ǝɥʇ ℲℲo sᴉ uᴉɐɹ uǝɥM
+of.options.RAIN.tooltip.1=˙ǝʌᴉʇɔɐ ꞁꞁᴉʇs ǝɹɐ
+
+of.options.SKY=ʎʞS
+of.options.SKY.tooltip.4=ʎʞS
+of.options.SKY.tooltip.3=ɹǝʍoꞁs 'ǝꞁqᴉsᴉʌ sᴉ ʎʞs - No  
+of.options.SKY.tooltip.2=ɹǝʇsɐɟ 'ǝꞁqᴉsᴉʌ ʇou sᴉ ʎʞs -  ℲℲo  
+of.options.SKY.tooltip.1=˙ǝꞁqᴉsᴉʌ ꞁꞁᴉʇs ǝɹɐ uns puɐ uooɯ ǝɥʇ ℲℲo sᴉ ʎʞs uǝɥM
+
+of.options.STARS=sɹɐʇS
+of.options.STARS.tooltip.3=sɹɐʇS
+of.options.STARS.tooltip.2=ɹǝʍoꞁs 'ǝꞁqᴉsᴉʌ ǝɹɐ sɹɐʇs - No  
+of.options.STARS.tooltip.1=ɹǝʇsɐɟ 'ǝꞁqᴉsᴉʌ ʇou ǝɹɐ sɹɐʇs -  ℲℲo  
+
+of.options.SUN_MOON=uooW ⅋ unS
+of.options.SUN_MOON.tooltip.3=uooW ⅋ unS
+of.options.SUN_MOON.tooltip.2=(ʇꞁnɐɟǝp) ǝꞁqᴉsᴉʌ ǝɹɐ uooɯ puɐ uns - No  
+of.options.SUN_MOON.tooltip.1=(ɹǝʇsɐɟ) ǝꞁqᴉsᴉʌ ʇou ǝɹɐ uooɯ puɐ uns -  ℲℲo  
+
+of.options.SHOW_CAPES=sǝdɐƆ ʍoɥS
+of.options.SHOW_CAPES.tooltip.3=sǝdɐƆ ʍoɥS
+of.options.SHOW_CAPES.tooltip.2=(ʇꞁnɐɟǝp) sǝdɐɔ ɹǝʎɐꞁd ʍoɥs - No  
+of.options.SHOW_CAPES.tooltip.1=sǝdɐɔ ɹǝʎɐꞁd ʍoɥs ʇou op - ℲℲo  
+
+of.options.TRANSLUCENT_BLOCKS=sʞɔoꞁq ʇuǝɔnꞁsuɐɹ⟘
+of.options.TRANSLUCENT_BLOCKS.tooltip.7=sʞɔoꞁq ʇuǝɔnꞁsuɐɹ⟘
+of.options.TRANSLUCENT_BLOCKS.tooltip.6=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.TRANSLUCENT_BLOCKS.tooltip.5=(ɹǝʍoꞁs) ƃuᴉpuǝꞁq ɹnoꞁoɔ ʇɔǝɹɹoɔ - ʎɔuɐℲ  
+of.options.TRANSLUCENT_BLOCKS.tooltip.4=(ɹǝʇsɐɟ) ƃuᴉpuǝꞁq ɹnoꞁoɔ ʇsɐɟ - ʇsɐℲ  
+of.options.TRANSLUCENT_BLOCKS.tooltip.3=sʞɔoꞁq ʇuǝɔnꞁsuɐɹʇ ɟo ƃuᴉpuǝꞁq ɹnoꞁoɔ ǝɥʇ sꞁoɹʇuoƆ
+of.options.TRANSLUCENT_BLOCKS.tooltip.2=(ǝɔᴉ 'ɹǝʇɐʍ 'ssɐꞁƃ pǝuᴉɐʇs) sɹnoꞁoɔ ʇuǝɹǝɟɟᴉp ɥʇᴉʍ
+of.options.TRANSLUCENT_BLOCKS.tooltip.1=˙ɯǝɥʇ uǝǝʍʇǝq ɹᴉɐ ɥʇᴉʍ ɹǝɥʇo ɥɔɐǝ puᴉɥǝq pǝɔɐꞁd uǝɥʍ
+
+of.options.HELD_ITEM_TOOLTIPS=sdᴉʇꞁoo⟘ ɯǝʇI pꞁǝH
+of.options.HELD_ITEM_TOOLTIPS.tooltip.3=sdᴉʇꞁooʇ ɯǝʇᴉ pꞁǝH
+of.options.HELD_ITEM_TOOLTIPS.tooltip.2=(ʇꞁnɐɟǝp) sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ ʍoɥs - No  
+of.options.HELD_ITEM_TOOLTIPS.tooltip.1=sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ ʍoɥs ʇou op - ℲℲo  
+
+of.options.ADVANCED_TOOLTIPS=sdᴉʇꞁoo⟘ pǝɔuɐʌp∀
+of.options.ADVANCED_TOOLTIPS.tooltip.6=sdᴉʇꞁooʇ pǝɔuɐʌp∀
+of.options.ADVANCED_TOOLTIPS.tooltip.5= sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs - No  
+of.options.ADVANCED_TOOLTIPS.tooltip.4=(ʇꞁnɐɟǝp) sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs ʇou op - ℲℲo  
+of.options.ADVANCED_TOOLTIPS.tooltip.3=ɹoɟ uoᴉʇɐɯɹoɟuᴉ pǝpuǝʇxǝ ʍoɥs sdᴉʇꞁooʇ pǝɔuɐʌp∀
+of.options.ADVANCED_TOOLTIPS.tooltip.2=suoᴉʇdo ɹǝpɐɥs ɹoɟ puɐ (ʎʇᴉꞁᴉqɐɹnp 'pᴉ) sɯǝʇᴉ
+of.options.ADVANCED_TOOLTIPS.tooltip.1=˙(ǝnꞁɐʌ ʇꞁnɐɟǝp 'ǝɔɹnos 'pᴉ)
+
+of.options.DROPPED_ITEMS=sɯǝʇI pǝddoɹp
+of.options.DROPPED_ITEMS.tooltip.4=sɯǝʇI pǝddoɹp
+of.options.DROPPED_ITEMS.tooltip.3=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.DROPPED_ITEMS.tooltip.2=(ɹǝʇsɐɟ) sɯǝʇᴉ pǝddoɹp pᘔ - ʇsɐℲ  
+of.options.DROPPED_ITEMS.tooltip.1=(ɹǝʍoꞁs) sɯǝʇᴉ pǝddoɹp pƐ - ʎɔuɐℲ  
+
+options.entityShadows.tooltip.3=sʍopɐɥS ʎʇᴉʇuƎ
+options.entityShadows.tooltip.2=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs - No  
+options.entityShadows.tooltip.1=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs ʇou op - ℲℲo  
+
+of.options.VIGNETTE=ǝʇʇǝuƃᴉΛ
+of.options.VIGNETTE.tooltip.8=sɹǝuɹoɔ uǝǝɹɔs ǝɥʇ suǝʞɹɐp ʎꞁʇɥƃᴉꞁs ɥɔᴉɥʍ ʇɔǝɟɟǝ ꞁɐnsᴉΛ
+of.options.VIGNETTE.tooltip.7=(ʇꞁnɐɟǝp) sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ǝɥʇ ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.VIGNETTE.tooltip.6=(ɹǝʇsɐɟ) pǝꞁqɐsᴉp ǝʇʇǝuƃᴉʌ - ʇsɐℲ  
+of.options.VIGNETTE.tooltip.5=(ɹǝʍoꞁs) pǝꞁqɐuǝ ǝʇʇǝuƃᴉʌ - ʎɔuɐℲ  
+of.options.VIGNETTE.tooltip.4='SԀℲ ǝɥʇ uo ʇɔǝɟɟǝ ʇuɐɔᴉɟᴉuƃᴉs ɐ ǝʌɐɥ ʎɐɯ ǝʇʇǝuƃᴉʌ ǝɥ⟘
+of.options.VIGNETTE.tooltip.3=˙uǝǝɹɔsꞁꞁnɟ ƃuᴉʎɐꞁd uǝɥʍ ʎꞁꞁɐᴉɔǝdsǝ
+of.options.VIGNETTE.tooltip.2=ʎꞁǝɟɐs uɐɔ puɐ ǝꞁʇqns ʎɹǝʌ sᴉ ʇɔǝɟɟǝ ǝʇʇǝuƃᴉʌ ǝɥ⟘
+of.options.VIGNETTE.tooltip.1=˙pǝꞁqɐsᴉp ǝq
+
+of.options.DYNAMIC_FOV=ΛoℲ ɔᴉɯɐuʎp
+of.options.DYNAMIC_FOV.tooltip.5=ΛoℲ ɔᴉɯɐuʎp
+of.options.DYNAMIC_FOV.tooltip.4=(ʇꞁnɐɟǝp) ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐuǝ - No  
+of.options.DYNAMIC_FOV.tooltip.3=ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐsᴉp - ℲℲo  
+of.options.DYNAMIC_FOV.tooltip.2= ƃuᴉʇuᴉɹds 'ƃuᴉʎꞁɟ uǝɥʍ (ΛoℲ) ʍǝᴉʌ ɟo pꞁǝᴉɟ ǝɥʇ sǝƃuɐɥƆ
+of.options.DYNAMIC_FOV.tooltip.1=˙ʍoq ɐ ƃuᴉꞁꞁnd ɹo
+
+of.options.DYNAMIC_LIGHTS=sʇɥƃᴉ˥ ɔᴉɯɐuʎp
+of.options.DYNAMIC_LIGHTS.tooltip.7=sʇɥƃᴉ˥ ɔᴉɯɐuʎp
+of.options.DYNAMIC_LIGHTS.tooltip.6=(ʇꞁnɐɟǝp) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ou - ℲℲo  
+of.options.DYNAMIC_LIGHTS.tooltip.5=(sɯ00ϛ ʎɹǝʌǝ pǝʇɐpdn) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ʇsɐɟ - ʇsɐℲ  
+of.options.DYNAMIC_LIGHTS.tooltip.4=(ǝɯᴉʇ-ꞁɐǝɹ uᴉ pǝʇɐpdn) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ʎɔuɐɟ - ʎɔuɐℲ  
+of.options.DYNAMIC_LIGHTS.tooltip.3=(˙ɔʇǝ 'ǝuoʇsʍoꞁƃ 'ɥɔɹoʇ) sɯǝʇᴉ ƃuᴉʇʇᴉɯǝ ʇɥƃᴉꞁ sǝꞁqɐuƎ
+of.options.DYNAMIC_LIGHTS.tooltip.2='puɐɥ uᴉ pꞁǝɥ uǝɥʍ ɯǝɥʇ punoɹɐ ƃuᴉɥʇʎɹǝʌǝ ǝʇɐuᴉɯnꞁꞁᴉ oʇ
+of.options.DYNAMIC_LIGHTS.tooltip.1=˙punoɹƃ ǝɥʇ uo pǝddoɹp ɹo ɹǝʎɐꞁd ɹǝɥʇo ʎq pǝddᴉnbǝ
+
+# Performance
+
+of.options.SMOOTH_FPS=SԀℲ ɥʇooɯS
+of.options.SMOOTH_FPS.tooltip.5=˙sɹǝɟɟnq ɹǝʌᴉɹp ɔᴉɥdɐɹƃ ǝɥʇ ƃuᴉɥsnꞁɟ ʎq SԀℲ sǝsᴉꞁᴉqɐʇS
+of.options.SMOOTH_FPS.tooltip.4=ǝʇɐnʇɔnꞁɟ ʎɐɯ SԀℲ 'uoᴉʇɐsᴉꞁᴉqɐʇs ou - ℲℲo  
+of.options.SMOOTH_FPS.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - No  
+of.options.SMOOTH_FPS.tooltip.2=ʇɔǝɟɟǝ sʇᴉ puɐ ʇuɐpuǝdǝp ɹǝʌᴉɹp sɔᴉɥdɐɹƃ sᴉ uoᴉʇdo sᴉɥ⟘
+of.options.SMOOTH_FPS.tooltip.1=˙ǝꞁqᴉsᴉʌ sʎɐʍꞁɐ ʇou sᴉ
+
+of.options.SMOOTH_WORLD=pꞁɹoM ɥʇooɯS
+of.options.SMOOTH_WORLD.tooltip.5=˙ɹǝʌɹǝs ꞁɐuɹǝʇuᴉ ǝɥʇ ʎq pǝsnɐɔ sǝʞᴉds ƃɐꞁ sǝʌoɯǝᴚ
+of.options.SMOOTH_WORLD.tooltip.4=ǝʇɐnʇɔnꞁɟ ʎɐɯ SԀℲ 'uoᴉʇɐsᴉꞁᴉqɐʇs ou - ℲℲo  
+of.options.SMOOTH_WORLD.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - No  
+of.options.SMOOTH_WORLD.tooltip.2=˙pɐoꞁ ɹǝʌɹǝs ꞁɐuɹǝʇuᴉ ǝɥʇ ƃuᴉʇnqᴉɹʇsᴉp ʎq SԀℲ sǝsᴉꞁᴉqɐʇS
+of.options.SMOOTH_WORLD.tooltip.1=˙(ɹǝʎɐꞁd ǝꞁƃuᴉs) spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ʎꞁuo ǝʌᴉʇɔǝɟɟƎ
+
+of.options.FAST_RENDER=ɹǝpuǝɹ ʇsɐℲ
+of.options.FAST_RENDER.tooltip.6=ɹǝpuǝɹ ʇsɐℲ
+of.options.FAST_RENDER.tooltip.5=(ʇꞁnɐɟǝp) ƃuᴉɹǝpuǝɹ pɹɐpuɐʇs - ℲℲo 
+of.options.FAST_RENDER.tooltip.4=(ɹǝʇsɐɟ) ƃuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo - No 
+of.options.FAST_RENDER.tooltip.3=sǝsɐǝɹɔǝp ɥɔᴉɥʍ ɯɥʇᴉɹoƃꞁɐ ƃuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo sǝs∩
+of.options.FAST_RENDER.tooltip.2=˙SԀℲ ǝɥʇ ǝsɐǝɹɔuᴉ ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ puɐ pɐoꞁ ∩Ԁפ ǝɥʇ
+of.options.FAST_RENDER.tooltip.1=˙spoɯ ǝɯos ɥʇᴉʍ ʇɔᴉꞁɟuoɔ uɐɔ uoᴉʇdo sᴉɥ⟘
+
+of.options.FAST_MATH=sɥʇɐW ʇsɐℲ
+of.options.FAST_MATH.tooltip.6=sɥʇɐW ʇsɐℲ
+of.options.FAST_MATH.tooltip.5=(ʇꞁnɐɟǝp) sɥʇɐɯ pɹɐpuɐʇs - ℲℲo 
+of.options.FAST_MATH.tooltip.4=sɥʇɐɯ ɹǝʇsɐɟ - No 
+of.options.FAST_MATH.tooltip.3=uɐɔ ɥɔᴉɥʍ suoᴉʇɔunɟ ()soɔ puɐ ()uᴉs pǝsᴉɯᴉʇdo sǝs∩
+of.options.FAST_MATH.tooltip.2=˙SԀℲ ǝɥʇ ǝsɐǝɹɔuᴉ puɐ ǝɥɔɐɔ ∩ԀƆ ǝɥʇ ǝsᴉꞁᴉʇn ɹǝʇʇǝq
+of.options.FAST_MATH.tooltip.1=˙uoᴉʇɐɹǝuǝƃ pꞁɹoʍ ǝɥʇ ʇɔǝɟɟɐ ʎꞁꞁɐɯᴉuᴉɯ uɐɔ uoᴉʇdo sᴉɥ⟘
+
+of.options.CHUNK_UPDATES=sǝʇɐpd∩ ʞunɥƆ
+of.options.CHUNK_UPDATES.tooltip.6=sǝʇɐpdn ʞunɥƆ
+of.options.CHUNK_UPDATES.tooltip.5=(ʇꞁnɐɟǝp) SԀℲ ɹǝɥƃᴉɥ 'ƃuᴉpɐoꞁ pꞁɹoʍ ɹǝʍoꞁs - ⥝ 
+of.options.CHUNK_UPDATES.tooltip.4=SԀℲ ɹǝʍoꞁ 'ƃuᴉpɐoꞁ pꞁɹoʍ ɹǝʇsɐɟ - Ɛ 
+of.options.CHUNK_UPDATES.tooltip.3=SԀℲ ʇsǝʍoꞁ 'ƃuᴉpɐoꞁ pꞁɹoʍ ʇsǝʇsɐɟ - ϛ 
+of.options.CHUNK_UPDATES.tooltip.2='ǝɯɐɹɟ pǝɹǝpuǝɹ ɹǝd sǝʇɐpdn ʞunɥɔ ɟo ɹǝqɯnN
+of.options.CHUNK_UPDATES.tooltip.1=˙ǝʇɐɹǝɯɐɹɟ ǝɥʇ ǝzᴉꞁᴉqɐʇsǝp ʎɐɯ sǝnꞁɐʌ ɹǝɥƃᴉɥ
+
+of.options.CHUNK_UPDATES_DYNAMIC=sǝʇɐpd∩ ɔᴉɯɐuʎp
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.5=sǝʇɐpdn ʞunɥɔ ɔᴉɯɐuʎp
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.4=(ʇꞁnɐɟǝp) ǝɯɐɹɟ ɹǝd sǝʇɐpdn ʞunɥɔ pɹɐpuɐʇs - ℲℲo 
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.3=ꞁꞁᴉʇs ƃuᴉpuɐʇs sᴉ ɹǝʎɐꞁd ǝɥʇ ǝꞁᴉɥʍ sǝʇɐpdn ǝɹoɯ - No 
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.2=ǝꞁᴉɥʍ sǝʇɐpdn ʞunɥɔ ǝɹoɯ ǝɔɹoɟ sǝʇɐpdn ɔᴉɯɐuʎp
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.1=˙ɹǝʇsɐɟ pꞁɹoʍ ǝɥʇ pɐoꞁ oʇ ꞁꞁᴉʇs ƃuᴉpuɐʇs sᴉ ɹǝʎɐꞁd ǝɥʇ
+
+of.options.LAZY_CHUNK_LOADING=ƃuᴉpɐo˥ ʞunɥƆ ʎzɐ˥
+of.options.LAZY_CHUNK_LOADING.tooltip.7=ƃuᴉpɐo˥ ʞunɥƆ ʎzɐ˥
+of.options.LAZY_CHUNK_LOADING.tooltip.6=ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʇꞁnɐɟǝp - ℲℲo 
+of.options.LAZY_CHUNK_LOADING.tooltip.5=(ɹǝɥʇooɯs) ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʎzɐꞁ - No 
+of.options.LAZY_CHUNK_LOADING.tooltip.4=ʎq ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs pǝʇɐɹƃǝʇuᴉ ǝɥʇ sɥʇooɯS
+of.options.LAZY_CHUNK_LOADING.tooltip.3=˙sʞɔᴉʇ ꞁɐɹǝʌǝs ɹǝʌo sʞunɥɔ ǝɥʇ ƃuᴉʇnqᴉɹʇsᴉp
+of.options.LAZY_CHUNK_LOADING.tooltip.2=˙ʎꞁʇɔǝɹɹoɔ pɐoꞁ ʇou op pꞁɹoʍ ǝɥʇ ɟo sʇɹɐd ɟᴉ ℲℲo ʇᴉ uɹn⟘
+of.options.LAZY_CHUNK_LOADING.tooltip.1=˙(ɹǝʎɐꞁd-ǝꞁƃuᴉs) spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ʎꞁuo ǝʌᴉʇɔǝɟɟƎ
+
+of.options.RENDER_REGIONS=suoᴉƃǝɹ ɹǝpuǝᴚ
+of.options.RENDER_REGIONS.tooltip.6=suoᴉƃǝɹ ɹǝpuǝᴚ
+of.options.RENDER_REGIONS.tooltip.5=(ʇꞁnɐɟǝp) suoᴉƃǝɹ ɹǝpuǝɹ ǝsn ʇou op - ℲℲo 
+of.options.RENDER_REGIONS.tooltip.4=suoᴉƃǝɹ ɹǝpuǝɹ ǝsn - No 
+of.options.RENDER_REGIONS.tooltip.3=ɹǝɥƃᴉɥ ʇɐ ƃuᴉɹǝpuǝɹ uᴉɐɹɹǝʇ ɹǝʇsɐɟ ʍoꞁꞁɐ suoᴉƃǝɹ ɹǝpuǝᴚ
+of.options.RENDER_REGIONS.tooltip.2=˙pǝꞁqɐuǝ ǝɹɐ soqΛ uǝɥʍ ǝʌᴉʇɔǝɟɟǝ ǝɹoW ˙sǝɔuɐʇsᴉp ɹǝpuǝɹ
+of.options.RENDER_REGIONS.tooltip.1=˙spɹɐɔ sɔᴉɥdɐɹƃ pǝʇɐɹƃǝʇuᴉ ɹoɟ pǝpuǝɯɯoɔǝɹ ʇoN
+
+of.options.SMART_ANIMATIONS=suoᴉʇɐɯᴉu∀ ʇɹɐɯS
+of.options.SMART_ANIMATIONS.tooltip.7=suoᴉʇɐɯᴉu∀ ʇɹɐɯS
+of.options.SMART_ANIMATIONS.tooltip.6=(ʇꞁnɐɟǝp) suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn ʇou op - ℲℲo 
+of.options.SMART_ANIMATIONS.tooltip.5=suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn - No 
+of.options.SMART_ANIMATIONS.tooltip.4= ǝɥʇ ǝʇɐɯᴉuɐ ʎꞁuo ꞁꞁᴉʍ ǝɯɐƃ ǝɥʇ suoᴉʇɐɯᴉuɐ ʇɹɐɯs ɥʇᴉM
+of.options.SMART_ANIMATIONS.tooltip.3=˙uǝǝɹɔs ǝɥʇ uo ǝꞁqᴉsᴉʌ ʎꞁʇuǝɹɹnɔ ǝɹɐ ɥɔᴉɥʍ sǝɹnʇxǝʇ
+of.options.SMART_ANIMATIONS.tooltip.2=˙SԀℲ ǝɥʇ sǝsɐǝɹɔuᴉ puɐ sǝʞᴉds ƃɐꞁ ʞɔᴉʇ ǝɥʇ sǝɔnpǝɹ sᴉɥ⟘
+of.options.SMART_ANIMATIONS.tooltip.1=˙sʞɔɐd ǝɔɹnosǝɹ pH puɐ sʞɔɐd poɯ ƃᴉq ɹoɟ ꞁnɟǝsn ʎꞁꞁɐᴉɔǝdsƎ
+
+# Animations
+
+of.options.animation.allOn=No ꞁꞁ∀
+of.options.animation.allOff=ℲℲo ꞁꞁ∀
+of.options.animation.dynamic=ɔᴉɯɐuʎp
+
+of.options.ANIMATED_WATER=pǝʇɐɯᴉu∀ ɹǝʇɐM
+of.options.ANIMATED_LAVA=pǝʇɐɯᴉu∀ ɐʌɐ˥
+of.options.ANIMATED_FIRE=pǝʇɐɯᴉu∀ ǝɹᴉℲ
+of.options.ANIMATED_PORTAL=pǝʇɐɯᴉu∀ ꞁɐʇɹoԀ
+of.options.ANIMATED_REDSTONE=pǝʇɐɯᴉu∀ ǝuoʇspǝᴚ
+of.options.ANIMATED_EXPLOSION=pǝʇɐɯᴉu∀ uoᴉsoꞁdxƎ
+of.options.ANIMATED_FLAME=pǝʇɐɯᴉu∀ ǝɯɐꞁℲ
+of.options.ANIMATED_SMOKE=pǝʇɐɯᴉu∀ ǝʞoɯS
+of.options.VOID_PARTICLES=sǝꞁɔᴉʇɹɐԀ pᴉoΛ
+of.options.WATER_PARTICLES=sǝꞁɔᴉʇɹɐԀ ɹǝʇɐM
+of.options.RAIN_SPLASH=ɥsɐꞁdS uᴉɐᴚ
+of.options.PORTAL_PARTICLES=sǝꞁɔᴉʇɹɐԀ ꞁɐʇɹoԀ
+of.options.POTION_PARTICLES=sǝꞁɔᴉʇɹɐԀ uoᴉʇoԀ
+of.options.DRIPPING_WATER_LAVA=ɐʌɐ˥/ɹǝʇɐM ƃuᴉddᴉɹp
+of.options.ANIMATED_TERRAIN=pǝʇɐɯᴉu∀ uᴉɐɹɹǝ⟘
+of.options.ANIMATED_TEXTURES=pǝʇɐɯᴉu∀ sǝɹnʇxǝ⟘
+of.options.FIREWORK_PARTICLES=sǝꞁɔᴉʇɹɐԀ ʞɹoʍǝɹᴉℲ
+
+# Other
+
+of.options.LAGOMETER=ɹǝʇǝɯoƃɐ˥
+of.options.LAGOMETER.tooltip.8=˙(ƐℲ) uǝǝɹɔs ƃnqǝp ǝɥʇ uo ɹǝʇǝɯoƃɐꞁ ǝɥʇ sʍoɥS
+of.options.LAGOMETER.tooltip.7=uoᴉʇɔǝꞁꞁoɔ ǝƃɐqɹɐƃ ʎɹoɯǝW - ǝƃuɐɹo *
+of.options.LAGOMETER.tooltip.6=ʞɔᴉ⟘ - uɐʎƆ *
+of.options.LAGOMETER.tooltip.5=sǝꞁqɐʇnɔǝxǝ pǝꞁnpǝɥɔS - ǝnꞁq *
+of.options.LAGOMETER.tooltip.4=pɐoꞁdn ʞunɥƆ - ǝꞁdɹnԀ *
+of.options.LAGOMETER.tooltip.3=sǝʇɐpdn ʞunɥƆ - pǝɹ *
+of.options.LAGOMETER.tooltip.2=ʞɔǝɥɔ ʎʇᴉꞁᴉqᴉsᴉΛ - ʍoꞁꞁǝ⅄ *
+of.options.LAGOMETER.tooltip.1=uᴉɐɹɹǝʇ ɹǝpuǝɹ - uǝǝɹפ *
+
+of.options.PROFILER=ɹǝꞁᴉɟoɹԀ ƃnqǝp
+of.options.PROFILER.tooltip.5=ɹǝꞁᴉɟoɹԀ ƃnqǝp
+of.options.PROFILER.tooltip.4=ɹǝʍoꞁs 'ǝʌᴉʇɔɐ sᴉ ɹǝꞁᴉɟoɹd ƃnqǝp - No  
+of.options.PROFILER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝꞁᴉɟoɹd ƃnqǝp - ℲℲo  
+of.options.PROFILER.tooltip.2=uoᴉʇɐɯɹoɟuᴉ ƃnqǝp sʍoɥs puɐ sʇɔǝꞁꞁoɔ ɹǝꞁᴉɟoɹd ƃnqǝp ǝɥ⟘
+of.options.PROFILER.tooltip.1=˙(ƐℲ) uǝdo sᴉ uǝǝɹɔs ƃnqǝp ǝɥʇ uǝɥʍ
+
+of.options.WEATHER=ɹǝɥʇɐǝM
+of.options.WEATHER.tooltip.5=ɹǝɥʇɐǝM
+of.options.WEATHER.tooltip.4=ɹǝʍoꞁs 'ǝʌᴉʇɔɐ sᴉ ɹǝɥʇɐǝʍ - No  
+of.options.WEATHER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝɥʇɐǝʍ - ℲℲo  
+of.options.WEATHER.tooltip.2=˙sɯɹoʇsɹǝpunɥʇ puɐ ʍous 'uᴉɐɹ sꞁoɹʇuoɔ ɹǝɥʇɐǝʍ ǝɥ⟘
+of.options.WEATHER.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ǝꞁqᴉssod ʎꞁuo sᴉ ꞁoɹʇuoɔ ɹǝɥʇɐǝM
+
+of.options.time.dayOnly=ʎꞁuo ʎɐp
+of.options.time.nightOnly=ʎꞁuo ʇɥƃᴉN
+
+of.options.TIME=ǝɯᴉ⟘
+of.options.TIME.tooltip.6=ǝɯᴉ⟘
+of.options.TIME.tooltip.5=sǝꞁɔʎɔ ʇɥƃᴉu/ʎɐp ꞁɐɯɹou - ʇꞁnɐɟǝp 
+of.options.TIME.tooltip.4=ʎꞁuo ʎɐp - ʎꞁuo ʎɐp 
+of.options.TIME.tooltip.3=ʎꞁuo ʇɥƃᴉu - ʎꞁuo ʇɥƃᴉN 
+of.options.TIME.tooltip.2=ǝpoɯ ƎΛI⟘∀ƎɹƆ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo sᴉ ƃuᴉʇʇǝs ǝɯᴉʇ ǝɥ⟘
+of.options.TIME.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ puɐ
+
+options.fullscreen.tooltip.5=uǝǝɹɔsꞁꞁnℲ
+options.fullscreen.tooltip.4=ǝpoɯ uǝǝɹɔsꞁꞁnɟ ǝsn - No  
+options.fullscreen.tooltip.3=ǝpoɯ ʍopuᴉʍ ǝsn - ℲℲo  
+options.fullscreen.tooltip.2=uɐɥʇ ɹǝʍoꞁs ɹo ɹǝʇsɐɟ ǝq ʎɐɯ ǝpoɯ uǝǝɹɔsꞁꞁnℲ
+options.fullscreen.tooltip.1=˙pɹɐɔ sɔᴉɥdɐɹƃ ǝɥʇ uo ƃuᴉpuǝdǝp 'ǝpoɯ ʍopuᴉʍ
+
+of.options.FULLSCREEN_MODE=ǝpoW uǝǝɹɔsꞁꞁnℲ
+of.options.FULLSCREEN_MODE.tooltip.5=ǝpoɯ uǝǝɹɔsꞁꞁnℲ
+of.options.FULLSCREEN_MODE.tooltip.4=ɹǝʍoꞁs 'uoᴉʇnꞁosǝɹ uǝǝɹɔs doʇʞsǝp ǝsn - ʇꞁnɐɟǝp  
+of.options.FULLSCREEN_MODE.tooltip.3=ɹǝʇsɐɟ ǝq ʎɐɯ 'uoᴉʇnꞁosǝɹ uǝǝɹɔs ɯoʇsnɔ ǝsn - HxM  
+of.options.FULLSCREEN_MODE.tooltip.2=˙(⥝⥝Ⅎ) ǝpoɯ uǝǝɹɔsꞁꞁnɟ uᴉ pǝsn sᴉ uoᴉʇnꞁosǝɹ pǝʇɔǝꞁǝs ǝɥ⟘
+of.options.FULLSCREEN_MODE.tooltip.1=˙ɹǝʇsɐɟ ǝq ʎꞁꞁɐɹǝuǝƃ pꞁnoɥs suoᴉʇnꞁosǝɹ ɹǝʍo˥
+
+of.options.SHOW_FPS=SԀℲ ʍoɥS
+of.options.SHOW_FPS.tooltip.7=˙uoᴉʇɐɯɹoɟuᴉ ɹǝpuǝɹ puɐ SԀℲ ʇɔɐdɯoɔ sʍoɥS
+of.options.SHOW_FPS.tooltip.6=ɯnɯᴉuᴉɯ/ǝƃɐɹǝʌɐ - sdℲ  
+of.options.SHOW_FPS.tooltip.5=sɹǝɹǝpuǝɹ ʞunɥɔ - :Ɔ  
+of.options.SHOW_FPS.tooltip.4=sǝᴉʇᴉʇuǝ ʞɔoꞁq + sǝᴉʇᴉʇuǝ pǝɹǝpuǝɹ - :Ǝ  
+of.options.SHOW_FPS.tooltip.3=sǝʇɐpdn ʞunɥɔ - :∩  
+of.options.SHOW_FPS.tooltip.2=ǝɥʇ uǝɥʍ uʍoɥs ʎꞁuo sᴉ uoᴉʇɐɯɹoɟuᴉ SԀℲ ʇɔɐdɯoɔ ǝɥ⟘
+of.options.SHOW_FPS.tooltip.1=˙ǝꞁqᴉsᴉʌ ʇou sᴉ uǝǝɹɔs ƃnqǝp
+
+of.options.save.45s=sϛ߈
+of.options.save.90s=s06
+of.options.save.3min=uᴉɯƐ
+of.options.save.6min=uᴉɯ9
+of.options.save.12min=uᴉɯᘔ⥝
+of.options.save.24min=uᴉɯ߈ᘔ
+
+of.options.AUTOSAVE_TICKS=ǝʌɐsoʇn∀
+of.options.AUTOSAVE_TICKS.tooltip.4=ꞁɐʌɹǝʇuI ǝʌɐsoʇn∀
+of.options.AUTOSAVE_TICKS.tooltip.3=ʇꞁnɐɟǝp - sϛ߈ 
+of.options.AUTOSAVE_TICKS.tooltip.2=˙ǝɔuɐʇsᴉp ɹǝpuǝɹ ǝɥʇ uo ƃuᴉpuǝdǝp sǝʞᴉds ƃɐꞁ ǝʇɐɹǝuǝƃ ʎɐɯ ǝʌɐsoʇn∀
+of.options.AUTOSAVE_TICKS.tooltip.1=˙pǝuǝdo sᴉ nuǝɯ ǝɯɐƃ ǝɥʇ uǝɥʍ pǝʌɐs osꞁɐ sᴉ pꞁɹoʍ ǝɥ⟘
+
+of.options.SCREENSHOT_SIZE=ǝzᴉS ʇoɥsuǝǝɹɔS
+of.options.SCREENSHOT_SIZE.tooltip.6=ǝzᴉS ʇoɥsuǝǝɹɔS
+of.options.SCREENSHOT_SIZE.tooltip.5=ǝzᴉs ʇoɥsuǝǝɹɔs ʇꞁnɐɟǝp - ʇꞁnɐɟǝp  
+of.options.SCREENSHOT_SIZE.tooltip.4=ǝzᴉs ʇoɥsuǝǝɹɔs ɯoʇsnɔ - x߈-xᘔ  
+of.options.SCREENSHOT_SIZE.tooltip.3=˙ʎɹoɯǝɯ ǝɹoɯ pǝǝu ʎɐɯ sʇoɥsuǝǝɹɔs ɹǝƃƃᴉq ƃuᴉɹnʇdɐƆ
+of.options.SCREENSHOT_SIZE.tooltip.2=˙ƃuᴉsɐᴉꞁɐᴉʇu∀ puɐ ɹǝpuǝɹ ʇsɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇoN
+of.options.SCREENSHOT_SIZE.tooltip.1=˙ʇɹoddns ɹǝɟɟnqǝɯɐɹɟ ∩Ԁפ sǝɹᴉnbǝᴚ
+
+of.options.SHOW_GL_ERRORS=sɹoɹɹƎ ˥פ ʍoɥS
+of.options.SHOW_GL_ERRORS.tooltip.6=sɹoɹɹƎ ˥פuǝdo ʍoɥS
+of.options.SHOW_GL_ERRORS.tooltip.5=˙ʇɐɥɔ ǝɥʇ uᴉ uʍoɥs ǝɹɐ sɹoɹɹǝ ˥פuǝdo pǝꞁqɐuǝ uǝɥM
+of.options.SHOW_GL_ERRORS.tooltip.4=puɐ ʇɔᴉꞁɟuoɔ uʍouʞ ɐ sᴉ ǝɹǝɥʇ ɟᴉ ʎꞁuo ʇᴉ ǝꞁqɐsᴉp
+of.options.SHOW_GL_ERRORS.tooltip.3=˙pǝxᴉɟ ǝq ʇ,uɐɔ sɹoɹɹǝ ǝɥʇ
+of.options.SHOW_GL_ERRORS.tooltip.2= ǝɥʇ uᴉ pǝƃƃoꞁ ꞁꞁᴉʇs ǝɹɐ sɹoɹɹǝ ǝɥʇ pǝꞁqɐsᴉp uǝɥM
+of.options.SHOW_GL_ERRORS.tooltip.1= ˙doɹp SԀℲ ʇuɐɔᴉɟᴉuƃᴉs ɐ ǝsnɐɔ ꞁꞁᴉʇs ʎɐɯ ʎǝɥʇ puɐ ƃoꞁ ɹoɹɹǝ
+
+# Chat Settings
+
+of.options.CHAT_BACKGROUND=punoɹƃʞɔɐq ʇɐɥƆ
+of.options.CHAT_BACKGROUND.tooltip.4=punoɹƃʞɔɐq ʇɐɥƆ
+of.options.CHAT_BACKGROUND.tooltip.3=ɥʇpᴉʍ pǝxᴉɟ - ʇꞁnɐɟǝp  
+of.options.CHAT_BACKGROUND.tooltip.2=ɥʇpᴉʍ ǝuᴉꞁ sǝɥɔʇɐɯ - ʇɔɐdɯoƆ  
+of.options.CHAT_BACKGROUND.tooltip.1=uǝppᴉɥ - ℲℲo  
+
+of.options.CHAT_SHADOW=ʍopɐɥS ʇɐɥƆ
+of.options.CHAT_SHADOW.tooltip.3=ʍopɐɥS ʇɐɥƆ
+of.options.CHAT_SHADOW.tooltip.2=ʍopɐɥs ʇxǝʇ ǝsn - No  
+of.options.CHAT_SHADOW.tooltip.1=ʍopɐɥs ʇxǝʇ ou - ℲℲo  

--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
@@ -29,23 +29,23 @@ of.message.an.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɥd
 of.message.an.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
 
 of.message.shaders.aa2=˙ƃuᴉsɐᴉꞁɐᴉʇu∀ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.aa1=˙ǝɯɐƃ ǝɥʇ ʇɹɐʇsǝɹ puɐ ℲℲo oʇ ƃuᴉsɐᴉꞁɐᴉʇu∀ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.aa1=˙ǝɯɐƃ ǝɥʇ ʇɹɐʇsǝɹ puɐ ℲℲO oʇ ƃuᴉsɐᴉꞁɐᴉʇu∀ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
 
 of.message.shaders.af2=˙ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.af1=˙ℲℲo oʇ ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.af1=˙ℲℲO oʇ ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
 
 of.message.shaders.fr2=˙ɹǝpuǝɹ ʇsɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.fr1=˙ℲℲo oʇ ɹǝpuǝɹ ʇsɐℲ <- ǝɔuɐɯɹoɟɹǝԀ ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.fr1=˙ℲℲO oʇ ɹǝpuǝɹ ʇsɐℲ <- ǝɔuɐɯɹoɟɹǝԀ ʇǝs ǝsɐǝꞁԀ
 
 of.message.shaders.an2=˙ɥdʎꞁƃɐu∀ pƐ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.an1=˙ℲℲo oʇ ɥdʎꞁƃɐu∀ pƐ <- ɹǝɥʇo ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.an1=˙ℲℲO oʇ ɥdʎꞁƃɐu∀ pƐ <- ɹǝɥʇo ʇǝs ǝsɐǝꞁԀ
 
-of.message.shaders.nv2=s% :uoᴉsɹǝʌ ǝuᴉℲᴉʇdo ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
+of.message.shaders.nv2=s% :uoᴉsɹǝʌ ǝuᴉℲᴉʇdO ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
 of.message.shaders.nv1=¿ǝnuᴉʇuoɔ oʇ ʇuɐʍ noʎ ǝɹns noʎ ǝɹ∀
 
 of.message.newVersion=§e%s§f :ǝꞁqɐꞁᴉɐʌɐ sᴉ uoᴉsɹǝʌ §eǝuᴉℲᴉʇdO§f ʍǝu ∀
 of.message.java64Bit=˙ǝɔuɐɯɹoɟɹǝd ǝsɐǝɹɔuᴉ oʇ §eɐʌɐſ ʇᴉq-߈9§f ꞁꞁɐʇsuᴉ uɐɔ no⅄
-of.message.openglError=(s%) s% :§eɹoɹɹƎ ˥פuǝdo§f
+of.message.openglError=(s%) s% :§eɹoɹɹƎ ˥פuǝdO§f
 
 of.message.shaders.loading=s% :sɹǝpɐɥs ƃuᴉpɐo˥
 
@@ -55,14 +55,14 @@ of.message.loadingVisibleChunks=sʞunɥɔ ǝꞁqᴉsᴉʌ ƃuᴉpɐo˥
 
 # Skin customization
 
-of.options.skinCustomisation.ofCape=˙˙˙ǝdɐƆ ǝuᴉℲᴉʇdo
+of.options.skinCustomisation.ofCape=˙˙˙ǝdɐƆ ǝuᴉℲᴉʇdO
 
-of.options.capeOF.title=ǝdɐƆ ǝuᴉℲᴉʇdo
-of.options.capeOF.openEditor=ɹoʇᴉpƎ ǝdɐƆ uǝdo
+of.options.capeOF.title=ǝdɐƆ ǝuᴉℲᴉʇdO
+of.options.capeOF.openEditor=ɹoʇᴉpƎ ǝdɐƆ uǝdO
 of.options.capeOF.reloadCape=ǝdɐƆ pɐolǝᴚ
 
-of.message.capeOF.openEditor=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ uǝdo pꞁnoɥs ɹoʇᴉpǝ ǝdɐɔ ǝuᴉℲᴉʇdo ǝɥ⟘
-of.message.capeOF.reloadCape=˙spuoɔǝs ϛƖ uᴉ pǝpɐoꞁǝɹ ǝq ꞁꞁᴉʍ ǝdɐɔ ǝɥ⟘
+of.message.capeOF.openEditor=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ uǝdo pꞁnoɥs ɹoʇᴉpǝ ǝdɐɔ ǝuᴉℲᴉʇdO ǝɥ⟘
+of.message.capeOF.reloadCape=˙spuoɔǝs ϛ⥝ uᴉ pǝpɐoꞁǝɹ ǝq ꞁꞁᴉʍ ǝdɐɔ ǝɥ⟘
 
 of.message.capeOF.error2=pǝꞁᴉɐɟ uoᴉʇɐɔᴉʇuǝɥʇnɐ ƃuɐɾoW.
 of.message.capeOF.error1=%s: ɹoɹɹƎ
@@ -93,7 +93,7 @@ options.renderDistance.tooltip.2=pǝʇɐɔoꞁꞁɐ W∀ɹ qפƐ spǝǝu 'ɯ߈�
 options.renderDistance.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo ǝɹɐ ɹɐℲ 9⥝ ɹǝʌo sǝnꞁɐΛ
 
 options.ao.tooltip.4=ƃuᴉʇɥƃᴉꞁ ɥʇooɯS
-options.ao.tooltip.3=(ɹǝʇsɐɟ) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs ou - ℲℲo  
+options.ao.tooltip.3=(ɹǝʇsɐɟ) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs ou - ℲℲO  
 options.ao.tooltip.2=(ɹǝʍoꞁs) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs ǝꞁdɯᴉs - ɯnɯᴉuᴉW  
 options.ao.tooltip.1=(ʇsǝʍoꞁs) ƃuᴉʇɥƃᴉꞁ ɥʇooɯs xǝꞁdɯoɔ - ɯnɯᴉxɐW  
 
@@ -107,18 +107,18 @@ of.options.framerateLimit.vsync=ɔuʎSΛ
 
 of.options.AO_LEVEL=ꞁǝʌǝ˥ ƃuᴉʇɥƃᴉ˥ ɥʇooɯS
 of.options.AO_LEVEL.tooltip.4=ꞁǝʌǝꞁ ƃuᴉʇɥƃᴉꞁ ɥʇooɯS
-of.options.AO_LEVEL.tooltip.3=sʍopɐɥs ou - ℲℲo  
+of.options.AO_LEVEL.tooltip.3=sʍopɐɥs ou - ℲℲO  
 of.options.AO_LEVEL.tooltip.2=sʍopɐɥs ʇɥƃᴉꞁ - %%0ϛ  
 of.options.AO_LEVEL.tooltip.1=sʍopɐɥs ʞɹɐp - %%00⥝  
 
 options.viewBobbing.tooltip.2=˙ʇuǝɯǝʌoɯ ɔᴉʇsᴉꞁɐǝɹ ǝɹoW
-options.viewBobbing.tooltip.1=˙sʇꞁnsǝɹ ʇsǝq ɹoɟ ℲℲo oʇ ʇᴉ ʇǝs sdɐɯdᴉɯ ƃuᴉsn uǝɥM
+options.viewBobbing.tooltip.1=˙sʇꞁnsǝɹ ʇsǝq ɹoɟ ℲℲO oʇ ʇᴉ ʇǝs sdɐɯdᴉɯ ƃuᴉsn uǝɥM
 
 options.guiScale.tooltip.6=ǝꞁɐɔS I∩פ
 options.guiScale.tooltip.5=ǝzᴉs ꞁɐɯᴉxɐɯ - oʇn∀  
 options.guiScale.tooltip.4=xƐ oʇ x⥝ - ǝƃɹɐ˥ 'ꞁɐɯɹoN 'ꞁꞁɐɯS  
 options.guiScale.tooltip.3=sʎɐꞁdsᴉp ʞ߈ uo ǝꞁqɐꞁᴉɐʌɐ - x0⥝ oʇ x߈  
-options.guiScale.tooltip.2=˙ǝpoɔᴉu∩ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ (˙˙˙ xϛ 'xƐ 'x⥝) sǝnꞁɐʌ ppo
+options.guiScale.tooltip.2=˙ǝpoɔᴉu∩ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ (˙˙˙ xϛ 'xƐ 'x⥝) sǝnꞁɐʌ ppO
 options.guiScale.tooltip.1=˙ɹǝʇsɐɟ ǝq ʎɐɯ I∩פ ɹǝꞁꞁɐɯs ∀
 
 options.vbo.tooltip.3=sʇɔǝɾqo ɹǝɟɟnq xǝʇɹǝΛ
@@ -146,7 +146,7 @@ of.options.FOG_FANCY=ƃoℲ
 of.options.FOG_FANCY.tooltip.6=ǝdʎʇ ƃoℲ
 of.options.FOG_FANCY.tooltip.5=ƃoɟ ɹǝʇsɐɟ - ʇsɐℲ  
 of.options.FOG_FANCY.tooltip.4=ɹǝʇʇǝq sʞooꞁ 'ƃoɟ ɹǝʍoꞁs - ʎɔuɐℲ  
-of.options.FOG_FANCY.tooltip.3=ʇsǝʇsɐɟ 'ƃoɟ ou - ℲℲo  
+of.options.FOG_FANCY.tooltip.3=ʇsǝʇsɐɟ 'ƃoɟ ou - ℲℲO  
 of.options.FOG_FANCY.tooltip.2= ǝɥʇ ʎq pǝʇɹoddns sᴉ ʇᴉ ɟᴉ ʎꞁuo ǝꞁqɐꞁᴉɐʌɐ sᴉ ƃoɟ ʎɔuɐɟ ǝɥ⟘
 of.options.FOG_FANCY.tooltip.1=˙pɹɐɔ ɔᴉɥdɐɹƃ
 
@@ -171,12 +171,12 @@ of.options.chunkLoading.multiCore=ǝɹoƆ-ᴉʇꞁnW
 of.options.shaders=˙˙˙sɹǝpɐɥS
 of.options.shadersTitle=sɹǝpɐɥS
 
-of.options.shaders.packNone=ℲℲo
+of.options.shaders.packNone=ℲℲO
 of.options.shaders.packDefault=(ꞁɐuɹǝʇuᴉ)
 
 of.options.shaders.ANTIALIASING=ƃuᴉsɐᴉꞁɐᴉʇu∀
 of.options.shaders.ANTIALIASING.tooltip.7=ƃuᴉsɐᴉꞁɐᴉʇu∀
-of.options.shaders.ANTIALIASING.tooltip.6=(ɹǝʇsɐɟ) ƃuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲo  
+of.options.shaders.ANTIALIASING.tooltip.6=(ɹǝʇsɐɟ) ƃuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲO  
 of.options.shaders.ANTIALIASING.tooltip.5=(ɹǝʍoꞁs) sǝƃpǝ puɐ sǝuᴉꞁ pǝsɐᴉꞁɐᴉʇuɐ - x߈ 'xᘔ ∀∀XℲ  
 of.options.shaders.ANTIALIASING.tooltip.4=sɥʇooɯs ɥɔᴉɥʍ ʇɔǝɟɟǝ ƃuᴉssǝɔoɹd-ʇsod ɐ sᴉ ∀∀XℲ
 of.options.shaders.ANTIALIASING.tooltip.3=˙suoᴉʇᴉsuɐɹʇ ɹoꞁoɔ dɹɐɥs puɐ sǝuᴉꞁ pǝƃƃɐɾ
@@ -185,8 +185,8 @@ of.options.shaders.ANTIALIASING.tooltip.1=  ˙ɹǝpuǝɹ ʇsɐℲ puɐ sɹǝpɐ�
 
 of.options.shaders.NORMAL_MAP=dɐW ꞁɐɯɹoN
 of.options.shaders.NORMAL_MAP.tooltip.7=dɐW ꞁɐɯɹoN
-of.options.shaders.NORMAL_MAP.tooltip.6= sdɐɯ ꞁɐɯɹou ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - No  
-of.options.shaders.NORMAL_MAP.tooltip.5=sdɐɯ ꞁɐɯɹou ǝꞁqɐsᴉp - ℲℲo  
+of.options.shaders.NORMAL_MAP.tooltip.6= sdɐɯ ꞁɐɯɹou ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - NO  
+of.options.shaders.NORMAL_MAP.tooltip.5=sdɐɯ ꞁɐɯɹou ǝꞁqɐsᴉp - ℲℲO  
 of.options.shaders.NORMAL_MAP.tooltip.4=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝq uɐɔ sdɐɯ ꞁɐɯɹoN
 of.options.shaders.NORMAL_MAP.tooltip.3=˙sǝɔɐɟɹns ꞁǝpoɯ ʇɐꞁɟ uo ʎɹʇǝɯoǝƃ pƐ ǝʇɐꞁnɯᴉs oʇ
 of.options.shaders.NORMAL_MAP.tooltip.2=ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ dɐɯ ꞁɐɯɹou ǝɥ⟘
@@ -194,8 +194,8 @@ of.options.shaders.NORMAL_MAP.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ
 
 of.options.shaders.SPECULAR_MAP=dɐW ɹɐꞁnɔǝdS
 of.options.shaders.SPECULAR_MAP.tooltip.7=dɐW ɹɐꞁnɔǝdS
-of.options.shaders.SPECULAR_MAP.tooltip.6=sdɐɯ ɹɐꞁnɔǝds ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - No  
-of.options.shaders.SPECULAR_MAP.tooltip.5=sdɐɯ ɹɐꞁnɔǝds ǝꞁqɐsᴉp - ℲℲo  
+of.options.shaders.SPECULAR_MAP.tooltip.6=sdɐɯ ɹɐꞁnɔǝds ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - NO  
+of.options.shaders.SPECULAR_MAP.tooltip.5=sdɐɯ ɹɐꞁnɔǝds ǝꞁqɐsᴉp - ℲℲO  
 of.options.shaders.SPECULAR_MAP.tooltip.4=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝq uɐɔ sdɐɯ ɹɐꞁnɔǝdS
 of.options.shaders.SPECULAR_MAP.tooltip.3=˙sʇɔǝɟɟǝ uoᴉʇɔǝꞁɟǝɹ ꞁɐᴉɔǝds ǝʇɐꞁnɯᴉs oʇ
 of.options.shaders.SPECULAR_MAP.tooltip.2=ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ dɐɯ ɹɐꞁnɔǝds ǝɥ⟘
@@ -233,21 +233,21 @@ of.options.shaders.HAND_DEPTH_MUL.tooltip.1=˙sʇɔǝɾqo pꞁǝɥpuɐɥ ɟo ƃu
 
 of.options.shaders.CLOUD_SHADOW=ʍopɐɥS pnoꞁƆ
 
-of.options.shaders.OLD_HAND_LIGHT=ʇɥƃᴉ˥ puɐH pꞁo
-of.options.shaders.OLD_HAND_LIGHT.tooltip.7=ʇɥƃᴉ˥ puɐH pꞁo
+of.options.shaders.OLD_HAND_LIGHT=ʇɥƃᴉ˥ puɐH pꞁO
+of.options.shaders.OLD_HAND_LIGHT.tooltip.7=ʇɥƃᴉ˥ puɐH pꞁO
 of.options.shaders.OLD_HAND_LIGHT.tooltip.6=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝp  
-of.options.shaders.OLD_HAND_LIGHT.tooltip.5=ʇɥƃᴉꞁpuɐɥ pꞁo ǝsn - No  
-of.options.shaders.OLD_HAND_LIGHT.tooltip.4=ʇɥƃᴉꞁpuɐɥ ʍǝu ǝsn - ℲℲo  
-of.options.shaders.OLD_HAND_LIGHT.tooltip.3=  ʎꞁuo ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥs sʍoꞁꞁɐ ʇɥƃᴉꞁ puɐɥ pꞁo
+of.options.shaders.OLD_HAND_LIGHT.tooltip.5=ʇɥƃᴉꞁpuɐɥ pꞁo ǝsn - NO  
+of.options.shaders.OLD_HAND_LIGHT.tooltip.4=ʇɥƃᴉꞁpuɐɥ ʍǝu ǝsn - ℲℲO  
+of.options.shaders.OLD_HAND_LIGHT.tooltip.3=  ʎꞁuo ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥs sʍoꞁꞁɐ ʇɥƃᴉꞁ puɐɥ pꞁO
 of.options.shaders.OLD_HAND_LIGHT.tooltip.2= puɐɥ uᴉɐɯ ǝɥʇ uᴉ sɯǝʇᴉ ƃuᴉʇʇᴉɯǝ ʇɥƃᴉꞁ ǝsᴉuƃoɔǝɹ
 of.options.shaders.OLD_HAND_LIGHT.tooltip.1=˙puɐɥ-ɟɟo ǝɥʇ uᴉ sɯǝʇᴉ ɥʇᴉʍ ʞɹoʍ osꞁɐ oʇ
 
-of.options.shaders.OLD_LIGHTING=ƃuᴉʇɥƃᴉ˥ pꞁo
-of.options.shaders.OLD_LIGHTING.tooltip.8=ƃuᴉʇɥƃᴉ˥ pꞁo
+of.options.shaders.OLD_LIGHTING=ƃuᴉʇɥƃᴉ˥ pꞁO
+of.options.shaders.OLD_LIGHTING.tooltip.8=ƃuᴉʇɥƃᴉ˥ pꞁO
 of.options.shaders.OLD_LIGHTING.tooltip.7=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝp  
-of.options.shaders.OLD_LIGHTING.tooltip.6=ƃuᴉʇɥƃᴉꞁ pꞁo ǝsn - No  
-of.options.shaders.OLD_LIGHTING.tooltip.5=ƃuᴉʇɥƃᴉꞁ pꞁo ǝsn ʇou op - ℲℲo  
-of.options.shaders.OLD_LIGHTING.tooltip.4= pǝᴉꞁddɐ ƃuᴉʇɥƃᴉꞁ pǝxᴉɟ ǝɥʇ sꞁoɹʇuoɔ ƃuᴉʇɥƃᴉꞁ pꞁo
+of.options.shaders.OLD_LIGHTING.tooltip.6=ƃuᴉʇɥƃᴉꞁ pꞁo ǝsn - NO  
+of.options.shaders.OLD_LIGHTING.tooltip.5=ƃuᴉʇɥƃᴉꞁ pꞁo ǝsn ʇou op - ℲℲO  
+of.options.shaders.OLD_LIGHTING.tooltip.4= pǝᴉꞁddɐ ƃuᴉʇɥƃᴉꞁ pǝxᴉɟ ǝɥʇ sꞁoɹʇuoɔ ƃuᴉʇɥƃᴉꞁ pꞁO
 of.options.shaders.OLD_LIGHTING.tooltip.3= ˙sǝpᴉs ʞɔoꞁq ǝɥʇ oʇ ɐꞁꞁᴉuɐʌ ʎq
 of.options.shaders.OLD_LIGHTING.tooltip.2= ǝpᴉʌoɹd ʎꞁꞁɐnsn sʍopɐɥs ǝsn ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥS
 of.options.shaders.OLD_LIGHTING.tooltip.1=˙uoᴉʇᴉsod uns ǝɥʇ uo ƃuᴉpuǝdǝp ƃuᴉʇɥƃᴉꞁ ɹǝʇʇǝq ɥɔnɯ
@@ -255,7 +255,7 @@ of.options.shaders.OLD_LIGHTING.tooltip.1=˙uoᴉʇᴉsod uns ǝɥʇ uo ƃuᴉpu
 of.options.shaders.DOWNLOAD=sɹǝpɐɥS pɐoꞁuʍop
 of.options.shaders.DOWNLOAD.tooltip.5=sɹǝpɐɥS pɐoꞁuʍop
 of.options.shaders.DOWNLOAD.tooltip.4= 
-of.options.shaders.DOWNLOAD.tooltip.3=˙ɹǝsʍoɹq ɐ uᴉ ǝƃɐd sʞɔɐd ɹǝpɐɥs ǝɥʇ suǝdo
+of.options.shaders.DOWNLOAD.tooltip.3=˙ɹǝsʍoɹq ɐ uᴉ ǝƃɐd sʞɔɐd ɹǝpɐɥs ǝɥʇ suǝdO
 of.options.shaders.DOWNLOAD.tooltip.2=,,ɹǝpꞁoℲ sɹǝpɐɥS,, ǝɥʇ uᴉ sʞɔɐd ɹǝpɐɥs pǝpɐoꞁuʍop ǝɥʇ ʇnԀ
 of.options.shaders.DOWNLOAD.tooltip.1=˙sɹǝpɐɥs pǝꞁꞁɐʇsuᴉ ɟo ʇsᴉꞁ ǝɥʇ uᴉ ɹɐǝddɐ ꞁꞁᴉʍ ʎǝɥʇ puɐ
 
@@ -278,8 +278,8 @@ of.options.performanceTitle=sƃuᴉʇʇǝS ǝɔuɐɯɹoɟɹǝԀ
 of.options.animations=˙˙˙suoᴉʇɐɯᴉu∀
 of.options.animationsTitle=sƃuᴉʇʇǝS uoᴉʇɐɯᴉu∀
 
-of.options.other=˙˙˙ɹǝɥʇo
-of.options.otherTitle=sƃuᴉʇʇǝS ɹǝɥʇo
+of.options.other=˙˙˙ɹǝɥʇO
+of.options.otherTitle=sƃuᴉʇʇǝS ɹǝɥʇO
 
 of.options.other.reset=˙˙˙sƃuᴉʇʇǝS oǝpᴉΛ ʇǝsǝᴚ
 
@@ -294,7 +294,7 @@ of.options.mipmap.trilinear=ɹɐǝuᴉꞁᴉɹ⟘
 
 options.mipmapLevels.tooltip.6=ɹǝʇʇǝq ʞooꞁ sʇɔǝɾqo ʇuɐʇsᴉp sǝʞɐɯ ɥɔᴉɥʍ ʇɔǝɟɟǝ ꞁɐnsᴉΛ
 options.mipmapLevels.tooltip.5=sꞁᴉɐʇǝp ǝɹnʇxǝʇ ǝɥʇ ƃuᴉɥʇooɯs ʎq
-options.mipmapLevels.tooltip.4=ƃuᴉɥʇooɯs ou - ℲℲo  
+options.mipmapLevels.tooltip.4=ƃuᴉɥʇooɯs ou - ℲℲO  
 options.mipmapLevels.tooltip.3=ƃuᴉɥʇooɯs ɯnɯᴉuᴉɯ - ⥝  
 options.mipmapLevels.tooltip.2=ƃuᴉɥʇooɯs ɯnɯᴉxɐɯ - ɯnɯᴉxɐW  
 options.mipmapLevels.tooltip.1=˙ǝɔuɐɯɹoɟɹǝd ǝɥʇ ʇɔǝɟɟɐ ʇou sǝop ʎꞁꞁɐnsn uoᴉʇdo sᴉɥ⟘
@@ -310,7 +310,7 @@ of.options.MIPMAP_TYPE.tooltip.1=(ʇsǝʍoꞁs) ƃuᴉɥʇooɯs ʇsǝuᴉɟ - ɹ
 
 of.options.AA_LEVEL=ƃuᴉsɐᴉꞁɐᴉʇu∀
 of.options.AA_LEVEL.tooltip.8=ƃuᴉsɐᴉꞁɐᴉʇu∀
-of.options.AA_LEVEL.tooltip.7=(ɹǝʇsɐɟ) ƃuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲo 
+of.options.AA_LEVEL.tooltip.7=(ɹǝʇsɐɟ) ƃuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲO 
 of.options.AA_LEVEL.tooltip.6=(ɹǝʍoꞁs) sǝƃpǝ puɐ sǝuᴉꞁ pǝsɐᴉꞁɐᴉʇuɐ - 9⥝-ᘔ 
 of.options.AA_LEVEL.tooltip.5= puɐ sǝuᴉꞁ pǝƃƃɐɾ sɥʇooɯs ƃuᴉsɐᴉꞁɐᴉʇu∀ ǝɥ⟘
 of.options.AA_LEVEL.tooltip.4=˙suoᴉʇᴉsuɐɹʇ ɹnoꞁoɔ dɹɐɥs
@@ -320,7 +320,7 @@ of.options.AA_LEVEL.tooltip.1=¡⟘ɹ∀⟘SƎɹ ɐ ɹǝʇɟɐ ǝʌᴉʇɔǝɟɟ
 
 of.options.AF_LEVEL=ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀
 of.options.AF_LEVEL.tooltip.6=ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀
-of.options.AF_LEVEL.tooltip.5=(ɹǝʇsɐɟ) ꞁᴉɐʇǝp ǝɹnʇxǝʇ pɹɐpuɐʇs (ʇꞁnɐɟǝp) - ℲℲo 
+of.options.AF_LEVEL.tooltip.5=(ɹǝʇsɐɟ) ꞁᴉɐʇǝp ǝɹnʇxǝʇ pɹɐpuɐʇs (ʇꞁnɐɟǝp) - ℲℲO 
 of.options.AF_LEVEL.tooltip.4=(ɹǝʍoꞁs) sǝɹnʇxǝʇ pǝddɐɯdᴉɯ uᴉ sꞁᴉɐʇǝp ɹǝuᴉɟ - 9⥝-ᘔ 
 of.options.AF_LEVEL.tooltip.3=uᴉ sꞁᴉɐʇǝp sǝɹoʇsǝɹ ƃuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉu∀ ǝɥ⟘
 of.options.AF_LEVEL.tooltip.2=˙sǝɹnʇxǝʇ pǝddɐɯdᴉɯ
@@ -328,60 +328,60 @@ of.options.AF_LEVEL.tooltip.1=˙SԀℲ ǝɥʇ ǝsɐǝɹɔǝp ʎꞁꞁɐᴉʇuɐ�
 
 of.options.CLEAR_WATER=ɹǝʇɐM ɹɐǝꞁƆ
 of.options.CLEAR_WATER.tooltip.3=ɹǝʇɐM ɹɐǝꞁƆ
-of.options.CLEAR_WATER.tooltip.2=ɹǝʇɐʍ ʇuǝɹɐdsuɐɹʇ 'ɹɐǝꞁɔ - No  
-of.options.CLEAR_WATER.tooltip.1=ɹǝʇɐʍ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CLEAR_WATER.tooltip.2=ɹǝʇɐʍ ʇuǝɹɐdsuɐɹʇ 'ɹɐǝꞁɔ - NO  
+of.options.CLEAR_WATER.tooltip.1=ɹǝʇɐʍ ʇꞁnɐɟǝp - ℲℲO  
 
 of.options.RANDOM_ENTITIES=sǝᴉʇᴉʇuƎ ɯopuɐᴚ
 of.options.RANDOM_ENTITIES.tooltip.5=sǝᴉʇᴉʇuƎ ɯopuɐᴚ
-of.options.RANDOM_ENTITIES.tooltip.4=ɹǝʇsɐɟ 'sǝᴉʇᴉʇuǝ ɯopuɐɹ ou - ℲℲo  
-of.options.RANDOM_ENTITIES.tooltip.3=ɹǝʍoꞁs 'sǝᴉʇᴉʇuǝ ɯopuɐɹ - No  
+of.options.RANDOM_ENTITIES.tooltip.4=ɹǝʇsɐɟ 'sǝᴉʇᴉʇuǝ ɯopuɐɹ ou - ℲℲO  
+of.options.RANDOM_ENTITIES.tooltip.3=ɹǝʍoꞁs 'sǝᴉʇᴉʇuǝ ɯopuɐɹ - NO  
 of.options.RANDOM_ENTITIES.tooltip.2=˙sǝᴉʇᴉʇuǝ ǝɯɐƃ ǝɥʇ ɹoɟ sǝɹnʇxǝʇ ɯopuɐɹ sǝsn sǝᴉʇᴉʇuǝ ɯopuɐᴚ
 of.options.RANDOM_ENTITIES.tooltip.1=˙sǝɹnʇxǝʇ ʎʇᴉʇuǝ ǝꞁdᴉʇꞁnɯ sɐɥ ɥɔᴉɥʍ ʞɔɐd ǝɔɹnosǝɹ ɐ spǝǝu ʇI
 
 of.options.BETTER_GRASS=ssɐɹפ ɹǝʇʇǝᗺ
 of.options.BETTER_GRASS.tooltip.4=ssɐɹפ ɹǝʇʇǝᗺ
-of.options.BETTER_GRASS.tooltip.3=ʇsǝʇsɐɟ 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ʇꞁnɐɟǝp - ℲℲo  
+of.options.BETTER_GRASS.tooltip.3=ʇsǝʇsɐɟ 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ʇꞁnɐɟǝp - ℲℲO  
 of.options.BETTER_GRASS.tooltip.2=ɹǝʍoꞁs 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ꞁꞁnɟ - ʇsɐℲ  
 of.options.BETTER_GRASS.tooltip.1=ʇsǝʍoꞁs 'ǝɹnʇxǝʇ ssɐɹƃ ǝpᴉs ɔᴉɯɐuʎp - ʎɔuɐℲ  
 
 of.options.BETTER_SNOW=ʍouS ɹǝʇʇǝᗺ
 of.options.BETTER_SNOW.tooltip.5=ʍouS ɹǝʇʇǝᗺ
-of.options.BETTER_SNOW.tooltip.4=ɹǝʇsɐɟ 'ʍous ʇꞁnɐɟǝp - ℲℲo  
-of.options.BETTER_SNOW.tooltip.3=ɹǝʍoꞁs 'ʍous ɹǝʇʇǝq - No  
+of.options.BETTER_SNOW.tooltip.4=ɹǝʇsɐɟ 'ʍous ʇꞁnɐɟǝp - ℲℲO  
+of.options.BETTER_SNOW.tooltip.3=ɹǝʍoꞁs 'ʍous ɹǝʇʇǝq - NO  
 of.options.BETTER_SNOW.tooltip.2=(ssɐɹƃ ꞁꞁɐʇ 'ǝɔuǝɟ) sʞɔoꞁq ʇuǝɹɐdsuɐɹʇ ɹǝpun ʍous sʍoɥS
 of.options.BETTER_SNOW.tooltip.1=˙sʞɔoꞁq ʍous ɥʇᴉʍ ƃuᴉɹǝpɹoq uǝɥʍ
 
 of.options.CUSTOM_FONTS=sʇuoℲ ɯoʇsnƆ
 of.options.CUSTOM_FONTS.tooltip.5=sʇuoℲ ɯoʇsnƆ
-of.options.CUSTOM_FONTS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sʇuoɟ ɯoʇsnɔ sǝsn - No  
-of.options.CUSTOM_FONTS.tooltip.3=ɹǝʇsɐɟ 'ʇuoɟ ʇꞁnɐɟǝp sǝsn - ℲℲo  
+of.options.CUSTOM_FONTS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sʇuoɟ ɯoʇsnɔ sǝsn - NO  
+of.options.CUSTOM_FONTS.tooltip.3=ɹǝʇsɐɟ 'ʇuoɟ ʇꞁnɐɟǝp sǝsn - ℲℲO  
 of.options.CUSTOM_FONTS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sʇuoɟ ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_FONTS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.CUSTOM_COLORS=sɹnoꞁoƆ ɯoʇsnƆ
 of.options.CUSTOM_COLORS.tooltip.5=sɹnoꞁoƆ ɯoʇsnƆ
-of.options.CUSTOM_COLORS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ ɯoʇsnɔ sǝsn - No  
-of.options.CUSTOM_COLORS.tooltip.3=ɹǝʇsɐɟ ' sɹnoꞁoɔ ʇꞁnɐɟǝp sǝsn - ℲℲo  
+of.options.CUSTOM_COLORS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ ɯoʇsnɔ sǝsn - NO  
+of.options.CUSTOM_COLORS.tooltip.3=ɹǝʇsɐɟ ' sɹnoꞁoɔ ʇꞁnɐɟǝp sǝsn - ℲℲO  
 of.options.CUSTOM_COLORS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ  sɹnoꞁoɔ ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_COLORS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.SWAMP_COLORS=sɹnoꞁoƆ dɯɐʍS
 of.options.SWAMP_COLORS.tooltip.4=sɹnoꞁoƆ dɯɐʍS
-of.options.SWAMP_COLORS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ dɯɐʍs ǝsn - No  
-of.options.SWAMP_COLORS.tooltip.2=ɹǝʇsɐɟ 'sɹnoꞁoɔ dɯɐʍs ǝsn ʇou op - ℲℲo  
+of.options.SWAMP_COLORS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ dɯɐʍs ǝsn - NO  
+of.options.SWAMP_COLORS.tooltip.2=ɹǝʇsɐɟ 'sɹnoꞁoɔ dɯɐʍs ǝsn ʇou op - ℲℲO  
 of.options.SWAMP_COLORS.tooltip.1=˙ɹǝʇɐʍ puɐ sǝuᴉʌ 'sǝʌɐǝꞁ 'ssɐɹƃ ʇɔǝɟɟɐ sɹnoꞁoɔ dɯɐʍs ǝɥ⟘
 
 of.options.SMOOTH_BIOMES=sǝɯoᴉq ɥʇooɯS
 of.options.SMOOTH_BIOMES.tooltip.6=sǝɯoᴉq ɥʇooɯS
-of.options.SMOOTH_BIOMES.tooltip.5=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs - No  
-of.options.SMOOTH_BIOMES.tooltip.4=ɹǝʇsɐɟ 'sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs ou - ℲℲo  
+of.options.SMOOTH_BIOMES.tooltip.5=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs - NO  
+of.options.SMOOTH_BIOMES.tooltip.4=ɹǝʇsɐɟ 'sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs ou - ℲℲO  
 of.options.SMOOTH_BIOMES.tooltip.3=puɐ ƃuᴉꞁdɯɐs ʎq ǝuop sᴉ sɹǝpɹoq ǝɯoᴉq ɟo ƃuᴉɥʇooɯs ǝɥ⟘
 of.options.SMOOTH_BIOMES.tooltip.2=˙sʞɔoꞁq ƃuᴉpunoɹɹns ꞁꞁɐ ɟo ɹnoꞁoɔ ǝɥʇ ƃuᴉƃɐɹǝʌɐ
 of.options.SMOOTH_BIOMES.tooltip.1=˙ɹǝʇɐʍ puɐ sǝuᴉʌ 'sǝʌɐǝꞁ 'ssɐɹƃ ǝɹɐ pǝʇɔǝɟɟ∀
 
 of.options.CONNECTED_TEXTURES=sǝɹnʇxǝ⟘ pǝʇɔǝuuoƆ
 of.options.CONNECTED_TEXTURES.tooltip.8=sǝɹnʇxǝ⟘ pǝʇɔǝuuoƆ
-of.options.CONNECTED_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ou - ℲℲo  
+of.options.CONNECTED_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ou - ℲℲO  
 of.options.CONNECTED_TEXTURES.tooltip.6=sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ʇsɐɟ - ʇsɐℲ  
 of.options.CONNECTED_TEXTURES.tooltip.5=sǝɹnʇxǝʇ pǝʇɔǝuuoɔ ʎɔuɐɟ - ʎɔuɐℲ  
 of.options.CONNECTED_TEXTURES.tooltip.4='ssɐꞁƃ ɟo sǝɹnʇxǝʇ ǝɥʇ suᴉoɾ sǝɹnʇxǝʇ pǝʇɔǝuuoƆ
@@ -391,8 +391,8 @@ of.options.CONNECTED_TEXTURES.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝ�
 
 of.options.NATURAL_TEXTURES=sǝɹnʇxǝ⟘ ꞁɐɹnʇɐN
 of.options.NATURAL_TEXTURES.tooltip.8=sǝɹnʇxǝ⟘ ꞁɐɹnʇɐN
-of.options.NATURAL_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ꞁɐɹnʇɐu ou - ℲℲo  
-of.options.NATURAL_TEXTURES.tooltip.6=sǝɹnʇxǝʇ ꞁɐɹnʇɐu ǝsn - No  
+of.options.NATURAL_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ꞁɐɹnʇɐu ou - ℲℲO  
+of.options.NATURAL_TEXTURES.tooltip.6=sǝɹnʇxǝʇ ꞁɐɹnʇɐu ǝsn - NO  
 of.options.NATURAL_TEXTURES.tooltip.5=uɹǝʇʇɐd ǝʞᴉꞁpᴉɹƃ ǝɥʇ ǝʌoɯǝɹ sǝɹnʇxǝʇ ꞁɐɹnʇɐN
 of.options.NATURAL_TEXTURES.tooltip.4=˙ǝdʎʇ ǝɯɐs ǝɥʇ ɟo sʞɔoꞁq ƃuᴉʇɐǝdǝɹ ʎq pǝʇɐǝɹɔ
 of.options.NATURAL_TEXTURES.tooltip.3=ǝsɐq ǝɥʇ ɟo sʇuɐᴉɹɐʌ pǝddᴉꞁɟ puɐ pǝʇɐʇoɹ sǝsn ʇI
@@ -401,8 +401,8 @@ of.options.NATURAL_TEXTURES.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥ�
 
 of.options.EMISSIVE_TEXTURES=sǝɹnʇxǝ⟘ ǝʌᴉssᴉɯƎ
 of.options.EMISSIVE_TEXTURES.tooltip.8=sǝɹnʇxǝ⟘ ǝʌᴉssᴉɯƎ
-of.options.EMISSIVE_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ou - ℲℲo  
-of.options.EMISSIVE_TEXTURES.tooltip.6=sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ǝsn - No  
+of.options.EMISSIVE_TEXTURES.tooltip.7=(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ou - ℲℲO  
+of.options.EMISSIVE_TEXTURES.tooltip.6=sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ǝsn - NO  
 of.options.EMISSIVE_TEXTURES.tooltip.5=sʎɐꞁɹǝʌo sɐ pǝɹǝpuǝɹ ǝɹɐ sǝɹnʇxǝʇ ǝʌᴉssᴉɯǝ ǝɥ⟘
 of.options.EMISSIVE_TEXTURES.tooltip.4=ǝʇɐꞁnɯᴉs oʇ pǝsn ǝq uɐɔ ʎǝɥ⟘ ˙ssǝuʇɥƃᴉɹq ꞁꞁnɟ ɥʇᴉʍ
 of.options.EMISSIVE_TEXTURES.tooltip.3=˙ǝɹnʇxǝʇ ǝsɐq ǝɥʇ ɟo sʇɹɐd ƃuᴉʇʇᴉɯǝ ʇɥƃᴉꞁ
@@ -411,29 +411,29 @@ of.options.EMISSIVE_TEXTURES.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.CUSTOM_SKY=ʎʞS ɯoʇsnƆ
 of.options.CUSTOM_SKY.tooltip.5=ʎʞS ɯoʇsnƆ
-of.options.CUSTOM_SKY.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ʎʞs ɯoʇsnɔ - No  
-of.options.CUSTOM_SKY.tooltip.3=ɹǝʇsɐɟ 'ʎʞs ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_SKY.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ʎʞs ɯoʇsnɔ - NO  
+of.options.CUSTOM_SKY.tooltip.3=ɹǝʇsɐɟ 'ʎʞs ʇꞁnɐɟǝp - ℲℲO  
 of.options.CUSTOM_SKY.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ ʎʞs ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_SKY.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.CUSTOM_ITEMS=sɯǝʇI ɯoʇsnƆ
 of.options.CUSTOM_ITEMS.tooltip.5=sɯǝʇI ɯoʇsnƆ
-of.options.CUSTOM_ITEMS.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ɯǝʇᴉ ɯoʇsnɔ - No  
-of.options.CUSTOM_ITEMS.tooltip.3=ɹǝʇsɐɟ 'sǝɹnʇxǝʇ ɯǝʇᴉ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_ITEMS.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sǝɹnʇxǝʇ ɯǝʇᴉ ɯoʇsnɔ - NO  
+of.options.CUSTOM_ITEMS.tooltip.3=ɹǝʇsɐɟ 'sǝɹnʇxǝʇ ɯǝʇᴉ ʇꞁnɐɟǝp - ℲℲO  
 of.options.CUSTOM_ITEMS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ ɯǝʇᴉ ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_ITEMS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.CUSTOM_ENTITY_MODELS=sꞁǝpoW ʎʇᴉʇuƎ ɯoʇsnƆ
 of.options.CUSTOM_ENTITY_MODELS.tooltip.5=sꞁǝpoW ʎʇᴉʇuƎ ɯoʇsnƆ
-of.options.CUSTOM_ENTITY_MODELS.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sꞁǝpoɯ ʎʇᴉʇuǝ ɯoʇsnɔ - No  
-of.options.CUSTOM_ENTITY_MODELS.tooltip.3=ɹǝʇsɐɟ 'sꞁǝpoɯ ʎʇᴉʇuǝ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_ENTITY_MODELS.tooltip.4=ʍoꞁs '(ʇꞁnɐɟǝp) sꞁǝpoɯ ʎʇᴉʇuǝ ɯoʇsnɔ - NO  
+of.options.CUSTOM_ENTITY_MODELS.tooltip.3=ɹǝʇsɐɟ 'sꞁǝpoɯ ʎʇᴉʇuǝ ʇꞁnɐɟǝp - ℲℲO  
 of.options.CUSTOM_ENTITY_MODELS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sꞁǝpoɯ ʎʇᴉʇuǝ ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_ENTITY_MODELS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.CUSTOM_GUIS=sI∩פ ɯoʇsnƆ
 of.options.CUSTOM_GUIS.tooltip.4=sI∩פ ɯoʇsnƆ
-of.options.CUSTOM_GUIS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sI∩פ ɯoʇsnɔ - No  
-of.options.CUSTOM_GUIS.tooltip.2=ɹǝʇsɐɟ 'sI∩פ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CUSTOM_GUIS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sI∩פ ɯoʇsnɔ - NO  
+of.options.CUSTOM_GUIS.tooltip.2=ɹǝʇsɐɟ 'sI∩פ ʇꞁnɐɟǝp - ℲℲO  
 of.options.CUSTOM_GUIS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sI∩פ ɯoʇsnɔ ǝɥ⟘
 
 # Details
@@ -443,13 +443,13 @@ of.options.CLOUDS.tooltip.7=spnoꞁƆ
 of.options.CLOUDS.tooltip.6=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
 of.options.CLOUDS.tooltip.5=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ - ʇsɐℲ  
 of.options.CLOUDS.tooltip.4=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥƃᴉɥ - ʎɔuɐℲ  
-of.options.CLOUDS.tooltip.3=ʇsǝʇsɐɟ 'spnoꞁɔ ou - ℲℲo  
+of.options.CLOUDS.tooltip.3=ʇsǝʇsɐɟ 'spnoꞁɔ ou - ℲℲO  
 of.options.CLOUDS.tooltip.2=˙pᘔ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʇsɐℲ
 of.options.CLOUDS.tooltip.1=˙pƐ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʎɔuɐℲ
 
 of.options.CLOUD_HEIGHT=ʇɥƃᴉǝH pnoꞁƆ
 of.options.CLOUD_HEIGHT.tooltip.3=ʇɥƃᴉǝH pnoꞁƆ
-of.options.CLOUD_HEIGHT.tooltip.2=ʇɥƃᴉǝɥ ʇꞁnɐɟǝp - ℲℲo  
+of.options.CLOUD_HEIGHT.tooltip.2=ʇɥƃᴉǝɥ ʇꞁnɐɟǝp - ℲℲO  
 of.options.CLOUD_HEIGHT.tooltip.1=ʇᴉɯᴉꞁ ʇɥƃᴉǝɥ pꞁɹoʍ ǝʌoqɐ - %%00⥝  
 
 of.options.TREES=sǝǝɹ⟘
@@ -466,30 +466,30 @@ of.options.RAIN.tooltip.7=ʍouS ⅋ uᴉɐᴚ
 of.options.RAIN.tooltip.6=sɔᴉɥdɐɹפ ƃuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
 of.options.RAIN.tooltip.5=ɹǝʇsɐɟ 'ʍous/uᴉɐɹ ʇɥƃᴉꞁ -  ʇsɐℲ  
 of.options.RAIN.tooltip.4=ɹǝʍoꞁs 'ʍous/uᴉɐɹ ʎʌɐǝɥ - ʎɔuɐℲ  
-of.options.RAIN.tooltip.3=ʇsǝʇsɐɟ 'ʍous/uᴉɐɹ ou - ℲℲo  
-of.options.RAIN.tooltip.2=spunos uᴉɐɹ puɐ sǝɥsɐꞁds ǝɥʇ ℲℲo sᴉ uᴉɐɹ uǝɥM
+of.options.RAIN.tooltip.3=ʇsǝʇsɐɟ 'ʍous/uᴉɐɹ ou - ℲℲO  
+of.options.RAIN.tooltip.2=spunos uᴉɐɹ puɐ sǝɥsɐꞁds ǝɥʇ ℲℲO sᴉ uᴉɐɹ uǝɥM
 of.options.RAIN.tooltip.1=˙ǝʌᴉʇɔɐ ꞁꞁᴉʇs ǝɹɐ
 
 of.options.SKY=ʎʞS
 of.options.SKY.tooltip.4=ʎʞS
-of.options.SKY.tooltip.3=ɹǝʍoꞁs 'ǝꞁqᴉsᴉʌ sᴉ ʎʞs - No  
-of.options.SKY.tooltip.2=ɹǝʇsɐɟ 'ǝꞁqᴉsᴉʌ ʇou sᴉ ʎʞs -  ℲℲo  
-of.options.SKY.tooltip.1=˙ǝꞁqᴉsᴉʌ ꞁꞁᴉʇs ǝɹɐ uns puɐ uooɯ ǝɥʇ ℲℲo sᴉ ʎʞs uǝɥM
+of.options.SKY.tooltip.3=ɹǝʍoꞁs 'ǝꞁqᴉsᴉʌ sᴉ ʎʞs - NO  
+of.options.SKY.tooltip.2=ɹǝʇsɐɟ 'ǝꞁqᴉsᴉʌ ʇou sᴉ ʎʞs -  ℲℲO  
+of.options.SKY.tooltip.1=˙ǝꞁqᴉsᴉʌ ꞁꞁᴉʇs ǝɹɐ uns puɐ uooɯ ǝɥʇ ℲℲO sᴉ ʎʞs uǝɥM
 
 of.options.STARS=sɹɐʇS
 of.options.STARS.tooltip.3=sɹɐʇS
-of.options.STARS.tooltip.2=ɹǝʍoꞁs 'ǝꞁqᴉsᴉʌ ǝɹɐ sɹɐʇs - No  
-of.options.STARS.tooltip.1=ɹǝʇsɐɟ 'ǝꞁqᴉsᴉʌ ʇou ǝɹɐ sɹɐʇs -  ℲℲo  
+of.options.STARS.tooltip.2=ɹǝʍoꞁs 'ǝꞁqᴉsᴉʌ ǝɹɐ sɹɐʇs - NO  
+of.options.STARS.tooltip.1=ɹǝʇsɐɟ 'ǝꞁqᴉsᴉʌ ʇou ǝɹɐ sɹɐʇs -  ℲℲO  
 
 of.options.SUN_MOON=uooW ⅋ unS
 of.options.SUN_MOON.tooltip.3=uooW ⅋ unS
-of.options.SUN_MOON.tooltip.2=(ʇꞁnɐɟǝp) ǝꞁqᴉsᴉʌ ǝɹɐ uooɯ puɐ uns - No  
-of.options.SUN_MOON.tooltip.1=(ɹǝʇsɐɟ) ǝꞁqᴉsᴉʌ ʇou ǝɹɐ uooɯ puɐ uns -  ℲℲo  
+of.options.SUN_MOON.tooltip.2=(ʇꞁnɐɟǝp) ǝꞁqᴉsᴉʌ ǝɹɐ uooɯ puɐ uns - NO  
+of.options.SUN_MOON.tooltip.1=(ɹǝʇsɐɟ) ǝꞁqᴉsᴉʌ ʇou ǝɹɐ uooɯ puɐ uns -  ℲℲO  
 
 of.options.SHOW_CAPES=sǝdɐƆ ʍoɥS
 of.options.SHOW_CAPES.tooltip.3=sǝdɐƆ ʍoɥS
-of.options.SHOW_CAPES.tooltip.2=(ʇꞁnɐɟǝp) sǝdɐɔ ɹǝʎɐꞁd ʍoɥs - No  
-of.options.SHOW_CAPES.tooltip.1=sǝdɐɔ ɹǝʎɐꞁd ʍoɥs ʇou op - ℲℲo  
+of.options.SHOW_CAPES.tooltip.2=(ʇꞁnɐɟǝp) sǝdɐɔ ɹǝʎɐꞁd ʍoɥs - NO  
+of.options.SHOW_CAPES.tooltip.1=sǝdɐɔ ɹǝʎɐꞁd ʍoɥs ʇou op - ℲℲO  
 
 of.options.TRANSLUCENT_BLOCKS=sʞɔoꞁq ʇuǝɔnꞁsuɐɹ⟘
 of.options.TRANSLUCENT_BLOCKS.tooltip.7=sʞɔoꞁq ʇuǝɔnꞁsuɐɹ⟘
@@ -502,13 +502,13 @@ of.options.TRANSLUCENT_BLOCKS.tooltip.1=˙ɯǝɥʇ uǝǝʍʇǝq ɹᴉɐ ɥʇᴉ�
 
 of.options.HELD_ITEM_TOOLTIPS=sdᴉʇꞁoo⟘ ɯǝʇI pꞁǝH
 of.options.HELD_ITEM_TOOLTIPS.tooltip.3=sdᴉʇꞁooʇ ɯǝʇᴉ pꞁǝH
-of.options.HELD_ITEM_TOOLTIPS.tooltip.2=(ʇꞁnɐɟǝp) sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ ʍoɥs - No  
-of.options.HELD_ITEM_TOOLTIPS.tooltip.1=sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ ʍoɥs ʇou op - ℲℲo  
+of.options.HELD_ITEM_TOOLTIPS.tooltip.2=(ʇꞁnɐɟǝp) sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ ʍoɥs - NO  
+of.options.HELD_ITEM_TOOLTIPS.tooltip.1=sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ ʍoɥs ʇou op - ℲℲO  
 
 of.options.ADVANCED_TOOLTIPS=sdᴉʇꞁoo⟘ pǝɔuɐʌp∀
 of.options.ADVANCED_TOOLTIPS.tooltip.6=sdᴉʇꞁooʇ pǝɔuɐʌp∀
-of.options.ADVANCED_TOOLTIPS.tooltip.5= sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs - No  
-of.options.ADVANCED_TOOLTIPS.tooltip.4=(ʇꞁnɐɟǝp) sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs ʇou op - ℲℲo  
+of.options.ADVANCED_TOOLTIPS.tooltip.5= sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs - NO  
+of.options.ADVANCED_TOOLTIPS.tooltip.4=(ʇꞁnɐɟǝp) sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs ʇou op - ℲℲO  
 of.options.ADVANCED_TOOLTIPS.tooltip.3=ɹoɟ uoᴉʇɐɯɹoɟuᴉ pǝpuǝʇxǝ ʍoɥs sdᴉʇꞁooʇ pǝɔuɐʌp∀
 of.options.ADVANCED_TOOLTIPS.tooltip.2=suoᴉʇdo ɹǝpɐɥs ɹoɟ puɐ (ʎʇᴉꞁᴉqɐɹnp 'pᴉ) sɯǝʇᴉ
 of.options.ADVANCED_TOOLTIPS.tooltip.1=˙(ǝnꞁɐʌ ʇꞁnɐɟǝp 'ǝɔɹnos 'pᴉ)
@@ -520,8 +520,8 @@ of.options.DROPPED_ITEMS.tooltip.2=(ɹǝʇsɐɟ) sɯǝʇᴉ pǝddoɹp pᘔ - ʇs
 of.options.DROPPED_ITEMS.tooltip.1=(ɹǝʍoꞁs) sɯǝʇᴉ pǝddoɹp pƐ - ʎɔuɐℲ  
 
 options.entityShadows.tooltip.3=sʍopɐɥS ʎʇᴉʇuƎ
-options.entityShadows.tooltip.2=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs - No  
-options.entityShadows.tooltip.1=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs ʇou op - ℲℲo  
+options.entityShadows.tooltip.2=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs - NO  
+options.entityShadows.tooltip.1=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs ʇou op - ℲℲO  
 
 of.options.VIGNETTE=ǝʇʇǝuƃᴉΛ
 of.options.VIGNETTE.tooltip.8=sɹǝuɹoɔ uǝǝɹɔs ǝɥʇ suǝʞɹɐp ʎꞁʇɥƃᴉꞁs ɥɔᴉɥʍ ʇɔǝɟɟǝ ꞁɐnsᴉΛ
@@ -535,14 +535,14 @@ of.options.VIGNETTE.tooltip.1=˙pǝꞁqɐsᴉp ǝq
 
 of.options.DYNAMIC_FOV=ΛoℲ ɔᴉɯɐuʎp
 of.options.DYNAMIC_FOV.tooltip.5=ΛoℲ ɔᴉɯɐuʎp
-of.options.DYNAMIC_FOV.tooltip.4=(ʇꞁnɐɟǝp) ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐuǝ - No  
-of.options.DYNAMIC_FOV.tooltip.3=ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐsᴉp - ℲℲo  
+of.options.DYNAMIC_FOV.tooltip.4=(ʇꞁnɐɟǝp) ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐuǝ - NO  
+of.options.DYNAMIC_FOV.tooltip.3=ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐsᴉp - ℲℲO  
 of.options.DYNAMIC_FOV.tooltip.2= ƃuᴉʇuᴉɹds 'ƃuᴉʎꞁɟ uǝɥʍ (ΛoℲ) ʍǝᴉʌ ɟo pꞁǝᴉɟ ǝɥʇ sǝƃuɐɥƆ
 of.options.DYNAMIC_FOV.tooltip.1=˙ʍoq ɐ ƃuᴉꞁꞁnd ɹo
 
 of.options.DYNAMIC_LIGHTS=sʇɥƃᴉ˥ ɔᴉɯɐuʎp
 of.options.DYNAMIC_LIGHTS.tooltip.7=sʇɥƃᴉ˥ ɔᴉɯɐuʎp
-of.options.DYNAMIC_LIGHTS.tooltip.6=(ʇꞁnɐɟǝp) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ou - ℲℲo  
+of.options.DYNAMIC_LIGHTS.tooltip.6=(ʇꞁnɐɟǝp) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ou - ℲℲO  
 of.options.DYNAMIC_LIGHTS.tooltip.5=(sɯ00ϛ ʎɹǝʌǝ pǝʇɐpdn) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ʇsɐɟ - ʇsɐℲ  
 of.options.DYNAMIC_LIGHTS.tooltip.4=(ǝɯᴉʇ-ꞁɐǝɹ uᴉ pǝʇɐpdn) sʇɥƃᴉꞁ ɔᴉɯɐuʎp ʎɔuɐɟ - ʎɔuɐℲ  
 of.options.DYNAMIC_LIGHTS.tooltip.3=(˙ɔʇǝ 'ǝuoʇsʍoꞁƃ 'ɥɔɹoʇ) sɯǝʇᴉ ƃuᴉʇʇᴉɯǝ ʇɥƃᴉꞁ sǝꞁqɐuƎ
@@ -553,30 +553,30 @@ of.options.DYNAMIC_LIGHTS.tooltip.1=˙punoɹƃ ǝɥʇ uo pǝddoɹp ɹo ɹǝʎɐ�
 
 of.options.SMOOTH_FPS=SԀℲ ɥʇooɯS
 of.options.SMOOTH_FPS.tooltip.5=˙sɹǝɟɟnq ɹǝʌᴉɹp ɔᴉɥdɐɹƃ ǝɥʇ ƃuᴉɥsnꞁɟ ʎq SԀℲ sǝsᴉꞁᴉqɐʇS
-of.options.SMOOTH_FPS.tooltip.4=ǝʇɐnʇɔnꞁɟ ʎɐɯ SԀℲ 'uoᴉʇɐsᴉꞁᴉqɐʇs ou - ℲℲo  
-of.options.SMOOTH_FPS.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - No  
+of.options.SMOOTH_FPS.tooltip.4=ǝʇɐnʇɔnꞁɟ ʎɐɯ SԀℲ 'uoᴉʇɐsᴉꞁᴉqɐʇs ou - ℲℲO  
+of.options.SMOOTH_FPS.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - NO  
 of.options.SMOOTH_FPS.tooltip.2=ʇɔǝɟɟǝ sʇᴉ puɐ ʇuɐpuǝdǝp ɹǝʌᴉɹp sɔᴉɥdɐɹƃ sᴉ uoᴉʇdo sᴉɥ⟘
 of.options.SMOOTH_FPS.tooltip.1=˙ǝꞁqᴉsᴉʌ sʎɐʍꞁɐ ʇou sᴉ
 
 of.options.SMOOTH_WORLD=pꞁɹoM ɥʇooɯS
 of.options.SMOOTH_WORLD.tooltip.5=˙ɹǝʌɹǝs ꞁɐuɹǝʇuᴉ ǝɥʇ ʎq pǝsnɐɔ sǝʞᴉds ƃɐꞁ sǝʌoɯǝᴚ
-of.options.SMOOTH_WORLD.tooltip.4=ǝʇɐnʇɔnꞁɟ ʎɐɯ SԀℲ 'uoᴉʇɐsᴉꞁᴉqɐʇs ou - ℲℲo  
-of.options.SMOOTH_WORLD.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - No  
+of.options.SMOOTH_WORLD.tooltip.4=ǝʇɐnʇɔnꞁɟ ʎɐɯ SԀℲ 'uoᴉʇɐsᴉꞁᴉqɐʇs ou - ℲℲO  
+of.options.SMOOTH_WORLD.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - NO  
 of.options.SMOOTH_WORLD.tooltip.2=˙pɐoꞁ ɹǝʌɹǝs ꞁɐuɹǝʇuᴉ ǝɥʇ ƃuᴉʇnqᴉɹʇsᴉp ʎq SԀℲ sǝsᴉꞁᴉqɐʇS
 of.options.SMOOTH_WORLD.tooltip.1=˙(ɹǝʎɐꞁd ǝꞁƃuᴉs) spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ʎꞁuo ǝʌᴉʇɔǝɟɟƎ
 
 of.options.FAST_RENDER=ɹǝpuǝɹ ʇsɐℲ
 of.options.FAST_RENDER.tooltip.6=ɹǝpuǝɹ ʇsɐℲ
-of.options.FAST_RENDER.tooltip.5=(ʇꞁnɐɟǝp) ƃuᴉɹǝpuǝɹ pɹɐpuɐʇs - ℲℲo 
-of.options.FAST_RENDER.tooltip.4=(ɹǝʇsɐɟ) ƃuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo - No 
+of.options.FAST_RENDER.tooltip.5=(ʇꞁnɐɟǝp) ƃuᴉɹǝpuǝɹ pɹɐpuɐʇs - ℲℲO 
+of.options.FAST_RENDER.tooltip.4=(ɹǝʇsɐɟ) ƃuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo - NO 
 of.options.FAST_RENDER.tooltip.3=sǝsɐǝɹɔǝp ɥɔᴉɥʍ ɯɥʇᴉɹoƃꞁɐ ƃuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo sǝs∩
 of.options.FAST_RENDER.tooltip.2=˙SԀℲ ǝɥʇ ǝsɐǝɹɔuᴉ ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ puɐ pɐoꞁ ∩Ԁפ ǝɥʇ
 of.options.FAST_RENDER.tooltip.1=˙spoɯ ǝɯos ɥʇᴉʍ ʇɔᴉꞁɟuoɔ uɐɔ uoᴉʇdo sᴉɥ⟘
 
 of.options.FAST_MATH=sɥʇɐW ʇsɐℲ
 of.options.FAST_MATH.tooltip.6=sɥʇɐW ʇsɐℲ
-of.options.FAST_MATH.tooltip.5=(ʇꞁnɐɟǝp) sɥʇɐɯ pɹɐpuɐʇs - ℲℲo 
-of.options.FAST_MATH.tooltip.4=sɥʇɐɯ ɹǝʇsɐɟ - No 
+of.options.FAST_MATH.tooltip.5=(ʇꞁnɐɟǝp) sɥʇɐɯ pɹɐpuɐʇs - ℲℲO 
+of.options.FAST_MATH.tooltip.4=sɥʇɐɯ ɹǝʇsɐɟ - NO 
 of.options.FAST_MATH.tooltip.3=uɐɔ ɥɔᴉɥʍ suoᴉʇɔunɟ ()soɔ puɐ ()uᴉs pǝsᴉɯᴉʇdo sǝs∩
 of.options.FAST_MATH.tooltip.2=˙SԀℲ ǝɥʇ ǝsɐǝɹɔuᴉ puɐ ǝɥɔɐɔ ∩ԀƆ ǝɥʇ ǝsᴉꞁᴉʇn ɹǝʇʇǝq
 of.options.FAST_MATH.tooltip.1=˙uoᴉʇɐɹǝuǝƃ pꞁɹoʍ ǝɥʇ ʇɔǝɟɟɐ ʎꞁꞁɐɯᴉuᴉɯ uɐɔ uoᴉʇdo sᴉɥ⟘
@@ -591,32 +591,32 @@ of.options.CHUNK_UPDATES.tooltip.1=˙ǝʇɐɹǝɯɐɹɟ ǝɥʇ ǝzᴉꞁᴉqɐʇ
 
 of.options.CHUNK_UPDATES_DYNAMIC=sǝʇɐpd∩ ɔᴉɯɐuʎp
 of.options.CHUNK_UPDATES_DYNAMIC.tooltip.5=sǝʇɐpdn ʞunɥɔ ɔᴉɯɐuʎp
-of.options.CHUNK_UPDATES_DYNAMIC.tooltip.4=(ʇꞁnɐɟǝp) ǝɯɐɹɟ ɹǝd sǝʇɐpdn ʞunɥɔ pɹɐpuɐʇs - ℲℲo 
-of.options.CHUNK_UPDATES_DYNAMIC.tooltip.3=ꞁꞁᴉʇs ƃuᴉpuɐʇs sᴉ ɹǝʎɐꞁd ǝɥʇ ǝꞁᴉɥʍ sǝʇɐpdn ǝɹoɯ - No 
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.4=(ʇꞁnɐɟǝp) ǝɯɐɹɟ ɹǝd sǝʇɐpdn ʞunɥɔ pɹɐpuɐʇs - ℲℲO 
+of.options.CHUNK_UPDATES_DYNAMIC.tooltip.3=ꞁꞁᴉʇs ƃuᴉpuɐʇs sᴉ ɹǝʎɐꞁd ǝɥʇ ǝꞁᴉɥʍ sǝʇɐpdn ǝɹoɯ - NO 
 of.options.CHUNK_UPDATES_DYNAMIC.tooltip.2=ǝꞁᴉɥʍ sǝʇɐpdn ʞunɥɔ ǝɹoɯ ǝɔɹoɟ sǝʇɐpdn ɔᴉɯɐuʎp
 of.options.CHUNK_UPDATES_DYNAMIC.tooltip.1=˙ɹǝʇsɐɟ pꞁɹoʍ ǝɥʇ pɐoꞁ oʇ ꞁꞁᴉʇs ƃuᴉpuɐʇs sᴉ ɹǝʎɐꞁd ǝɥʇ
 
 of.options.LAZY_CHUNK_LOADING=ƃuᴉpɐo˥ ʞunɥƆ ʎzɐ˥
 of.options.LAZY_CHUNK_LOADING.tooltip.7=ƃuᴉpɐo˥ ʞunɥƆ ʎzɐ˥
-of.options.LAZY_CHUNK_LOADING.tooltip.6=ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʇꞁnɐɟǝp - ℲℲo 
-of.options.LAZY_CHUNK_LOADING.tooltip.5=(ɹǝɥʇooɯs) ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʎzɐꞁ - No 
+of.options.LAZY_CHUNK_LOADING.tooltip.6=ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʇꞁnɐɟǝp - ℲℲO 
+of.options.LAZY_CHUNK_LOADING.tooltip.5=(ɹǝɥʇooɯs) ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʎzɐꞁ - NO 
 of.options.LAZY_CHUNK_LOADING.tooltip.4=ʎq ƃuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs pǝʇɐɹƃǝʇuᴉ ǝɥʇ sɥʇooɯS
 of.options.LAZY_CHUNK_LOADING.tooltip.3=˙sʞɔᴉʇ ꞁɐɹǝʌǝs ɹǝʌo sʞunɥɔ ǝɥʇ ƃuᴉʇnqᴉɹʇsᴉp
-of.options.LAZY_CHUNK_LOADING.tooltip.2=˙ʎꞁʇɔǝɹɹoɔ pɐoꞁ ʇou op pꞁɹoʍ ǝɥʇ ɟo sʇɹɐd ɟᴉ ℲℲo ʇᴉ uɹn⟘
+of.options.LAZY_CHUNK_LOADING.tooltip.2=˙ʎꞁʇɔǝɹɹoɔ pɐoꞁ ʇou op pꞁɹoʍ ǝɥʇ ɟo sʇɹɐd ɟᴉ ℲℲO ʇᴉ uɹn⟘
 of.options.LAZY_CHUNK_LOADING.tooltip.1=˙(ɹǝʎɐꞁd-ǝꞁƃuᴉs) spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ʎꞁuo ǝʌᴉʇɔǝɟɟƎ
 
 of.options.RENDER_REGIONS=suoᴉƃǝɹ ɹǝpuǝᴚ
 of.options.RENDER_REGIONS.tooltip.6=suoᴉƃǝɹ ɹǝpuǝᴚ
-of.options.RENDER_REGIONS.tooltip.5=(ʇꞁnɐɟǝp) suoᴉƃǝɹ ɹǝpuǝɹ ǝsn ʇou op - ℲℲo 
-of.options.RENDER_REGIONS.tooltip.4=suoᴉƃǝɹ ɹǝpuǝɹ ǝsn - No 
+of.options.RENDER_REGIONS.tooltip.5=(ʇꞁnɐɟǝp) suoᴉƃǝɹ ɹǝpuǝɹ ǝsn ʇou op - ℲℲO 
+of.options.RENDER_REGIONS.tooltip.4=suoᴉƃǝɹ ɹǝpuǝɹ ǝsn - NO 
 of.options.RENDER_REGIONS.tooltip.3=ɹǝɥƃᴉɥ ʇɐ ƃuᴉɹǝpuǝɹ uᴉɐɹɹǝʇ ɹǝʇsɐɟ ʍoꞁꞁɐ suoᴉƃǝɹ ɹǝpuǝᴚ
 of.options.RENDER_REGIONS.tooltip.2=˙pǝꞁqɐuǝ ǝɹɐ soqΛ uǝɥʍ ǝʌᴉʇɔǝɟɟǝ ǝɹoW ˙sǝɔuɐʇsᴉp ɹǝpuǝɹ
 of.options.RENDER_REGIONS.tooltip.1=˙spɹɐɔ sɔᴉɥdɐɹƃ pǝʇɐɹƃǝʇuᴉ ɹoɟ pǝpuǝɯɯoɔǝɹ ʇoN
 
 of.options.SMART_ANIMATIONS=suoᴉʇɐɯᴉu∀ ʇɹɐɯS
 of.options.SMART_ANIMATIONS.tooltip.7=suoᴉʇɐɯᴉu∀ ʇɹɐɯS
-of.options.SMART_ANIMATIONS.tooltip.6=(ʇꞁnɐɟǝp) suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn ʇou op - ℲℲo 
-of.options.SMART_ANIMATIONS.tooltip.5=suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn - No 
+of.options.SMART_ANIMATIONS.tooltip.6=(ʇꞁnɐɟǝp) suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn ʇou op - ℲℲO 
+of.options.SMART_ANIMATIONS.tooltip.5=suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn - NO 
 of.options.SMART_ANIMATIONS.tooltip.4= ǝɥʇ ǝʇɐɯᴉuɐ ʎꞁuo ꞁꞁᴉʍ ǝɯɐƃ ǝɥʇ suoᴉʇɐɯᴉuɐ ʇɹɐɯs ɥʇᴉM
 of.options.SMART_ANIMATIONS.tooltip.3=˙uǝǝɹɔs ǝɥʇ uo ǝꞁqᴉsᴉʌ ʎꞁʇuǝɹɹnɔ ǝɹɐ ɥɔᴉɥʍ sǝɹnʇxǝʇ
 of.options.SMART_ANIMATIONS.tooltip.2=˙SԀℲ ǝɥʇ sǝsɐǝɹɔuᴉ puɐ sǝʞᴉds ƃɐꞁ ʞɔᴉʇ ǝɥʇ sǝɔnpǝɹ sᴉɥ⟘
@@ -624,8 +624,8 @@ of.options.SMART_ANIMATIONS.tooltip.1=˙sʞɔɐd ǝɔɹnosǝɹ pH puɐ sʞɔɐd 
 
 # Animations
 
-of.options.animation.allOn=No ꞁꞁ∀
-of.options.animation.allOff=ℲℲo ꞁꞁ∀
+of.options.animation.allOn=NO ꞁꞁ∀
+of.options.animation.allOff=ℲℲO ꞁꞁ∀
 of.options.animation.dynamic=ɔᴉɯɐuʎp
 
 of.options.ANIMATED_WATER=pǝʇɐɯᴉu∀ ɹǝʇɐM
@@ -650,42 +650,42 @@ of.options.FIREWORK_PARTICLES=sǝꞁɔᴉʇɹɐԀ ʞɹoʍǝɹᴉℲ
 
 of.options.LAGOMETER=ɹǝʇǝɯoƃɐ˥
 of.options.LAGOMETER.tooltip.8=˙(ƐℲ) uǝǝɹɔs ƃnqǝp ǝɥʇ uo ɹǝʇǝɯoƃɐꞁ ǝɥʇ sʍoɥS
-of.options.LAGOMETER.tooltip.7=uoᴉʇɔǝꞁꞁoɔ ǝƃɐqɹɐƃ ʎɹoɯǝW - ǝƃuɐɹo *
+of.options.LAGOMETER.tooltip.7=uoᴉʇɔǝꞁꞁoɔ ǝƃɐqɹɐƃ ʎɹoɯǝW - ǝƃuɐɹO *
 of.options.LAGOMETER.tooltip.6=ʞɔᴉ⟘ - uɐʎƆ *
-of.options.LAGOMETER.tooltip.5=sǝꞁqɐʇnɔǝxǝ pǝꞁnpǝɥɔS - ǝnꞁq *
+of.options.LAGOMETER.tooltip.5=sǝꞁqɐʇnɔǝxǝ pǝꞁnpǝɥɔS - ǝnꞁᗺ *
 of.options.LAGOMETER.tooltip.4=pɐoꞁdn ʞunɥƆ - ǝꞁdɹnԀ *
-of.options.LAGOMETER.tooltip.3=sǝʇɐpdn ʞunɥƆ - pǝɹ *
+of.options.LAGOMETER.tooltip.3=sǝʇɐpdn ʞunɥƆ - pǝᴚ *
 of.options.LAGOMETER.tooltip.2=ʞɔǝɥɔ ʎʇᴉꞁᴉqᴉsᴉΛ - ʍoꞁꞁǝ⅄ *
-of.options.LAGOMETER.tooltip.1=uᴉɐɹɹǝʇ ɹǝpuǝɹ - uǝǝɹפ *
+of.options.LAGOMETER.tooltip.1=uᴉɐɹɹǝʇ ɹǝpuǝᴚ - uǝǝɹפ *
 
 of.options.PROFILER=ɹǝꞁᴉɟoɹԀ ƃnqǝp
 of.options.PROFILER.tooltip.5=ɹǝꞁᴉɟoɹԀ ƃnqǝp
-of.options.PROFILER.tooltip.4=ɹǝʍoꞁs 'ǝʌᴉʇɔɐ sᴉ ɹǝꞁᴉɟoɹd ƃnqǝp - No  
-of.options.PROFILER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝꞁᴉɟoɹd ƃnqǝp - ℲℲo  
+of.options.PROFILER.tooltip.4=ɹǝʍoꞁs 'ǝʌᴉʇɔɐ sᴉ ɹǝꞁᴉɟoɹd ƃnqǝp - NO  
+of.options.PROFILER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝꞁᴉɟoɹd ƃnqǝp - ℲℲO  
 of.options.PROFILER.tooltip.2=uoᴉʇɐɯɹoɟuᴉ ƃnqǝp sʍoɥs puɐ sʇɔǝꞁꞁoɔ ɹǝꞁᴉɟoɹd ƃnqǝp ǝɥ⟘
 of.options.PROFILER.tooltip.1=˙(ƐℲ) uǝdo sᴉ uǝǝɹɔs ƃnqǝp ǝɥʇ uǝɥʍ
 
 of.options.WEATHER=ɹǝɥʇɐǝM
 of.options.WEATHER.tooltip.5=ɹǝɥʇɐǝM
-of.options.WEATHER.tooltip.4=ɹǝʍoꞁs 'ǝʌᴉʇɔɐ sᴉ ɹǝɥʇɐǝʍ - No  
-of.options.WEATHER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝɥʇɐǝʍ - ℲℲo  
+of.options.WEATHER.tooltip.4=ɹǝʍoꞁs 'ǝʌᴉʇɔɐ sᴉ ɹǝɥʇɐǝʍ - NO  
+of.options.WEATHER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝɥʇɐǝʍ - ℲℲO  
 of.options.WEATHER.tooltip.2=˙sɯɹoʇsɹǝpunɥʇ puɐ ʍous 'uᴉɐɹ sꞁoɹʇuoɔ ɹǝɥʇɐǝʍ ǝɥ⟘
 of.options.WEATHER.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ǝꞁqᴉssod ʎꞁuo sᴉ ꞁoɹʇuoɔ ɹǝɥʇɐǝM
 
-of.options.time.dayOnly=ʎꞁuo ʎɐp
+of.options.time.dayOnly=ʎꞁuo ʎɐᗡ
 of.options.time.nightOnly=ʎꞁuo ʇɥƃᴉN
 
 of.options.TIME=ǝɯᴉ⟘
 of.options.TIME.tooltip.6=ǝɯᴉ⟘
 of.options.TIME.tooltip.5=sǝꞁɔʎɔ ʇɥƃᴉu/ʎɐp ꞁɐɯɹou - ʇꞁnɐɟǝp 
-of.options.TIME.tooltip.4=ʎꞁuo ʎɐp - ʎꞁuo ʎɐp 
+of.options.TIME.tooltip.4=ʎꞁuo ʎɐp - ʎꞁuo ʎɐᗡ 
 of.options.TIME.tooltip.3=ʎꞁuo ʇɥƃᴉu - ʎꞁuo ʇɥƃᴉN 
 of.options.TIME.tooltip.2=ǝpoɯ ƎΛI⟘∀ƎɹƆ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo sᴉ ƃuᴉʇʇǝs ǝɯᴉʇ ǝɥ⟘
 of.options.TIME.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ puɐ
 
 options.fullscreen.tooltip.5=uǝǝɹɔsꞁꞁnℲ
-options.fullscreen.tooltip.4=ǝpoɯ uǝǝɹɔsꞁꞁnɟ ǝsn - No  
-options.fullscreen.tooltip.3=ǝpoɯ ʍopuᴉʍ ǝsn - ℲℲo  
+options.fullscreen.tooltip.4=ǝpoɯ uǝǝɹɔsꞁꞁnɟ ǝsn - NO  
+options.fullscreen.tooltip.3=ǝpoɯ ʍopuᴉʍ ǝsn - ℲℲO  
 options.fullscreen.tooltip.2=uɐɥʇ ɹǝʍoꞁs ɹo ɹǝʇsɐɟ ǝq ʎɐɯ ǝpoɯ uǝǝɹɔsꞁꞁnℲ
 options.fullscreen.tooltip.1=˙pɹɐɔ sɔᴉɥdɐɹƃ ǝɥʇ uo ƃuᴉpuǝdǝp 'ǝpoɯ ʍopuᴉʍ
 
@@ -740,9 +740,9 @@ of.options.CHAT_BACKGROUND=punoɹƃʞɔɐq ʇɐɥƆ
 of.options.CHAT_BACKGROUND.tooltip.4=punoɹƃʞɔɐq ʇɐɥƆ
 of.options.CHAT_BACKGROUND.tooltip.3=ɥʇpᴉʍ pǝxᴉɟ - ʇꞁnɐɟǝp  
 of.options.CHAT_BACKGROUND.tooltip.2=ɥʇpᴉʍ ǝuᴉꞁ sǝɥɔʇɐɯ - ʇɔɐdɯoƆ  
-of.options.CHAT_BACKGROUND.tooltip.1=uǝppᴉɥ - ℲℲo  
+of.options.CHAT_BACKGROUND.tooltip.1=uǝppᴉɥ - ℲℲO  
 
 of.options.CHAT_SHADOW=ʍopɐɥS ʇɐɥƆ
 of.options.CHAT_SHADOW.tooltip.3=ʍopɐɥS ʇɐɥƆ
-of.options.CHAT_SHADOW.tooltip.2=ʍopɐɥs ʇxǝʇ ǝsn - No  
-of.options.CHAT_SHADOW.tooltip.1=ʍopɐɥs ʇxǝʇ ou - ℲℲo  
+of.options.CHAT_SHADOW.tooltip.2=ʍopɐɥs ʇxǝʇ ǝsn - NO  
+of.options.CHAT_SHADOW.tooltip.1=ʍopɐɥs ʇxǝʇ ou - ℲℲO  


### PR DESCRIPTION
Since we have to please those 5 people out there that are playing in British English (upside down) with OptiFine.

I have reversed the order of the tooltip lines so they are readable if you tilt your head.