### PR TITLE
Simplify render distance tooltip

### DIFF
--- a/OptiFineDoc/assets/minecraft/optifine/lang/cs_cz.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/cs_cz.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Pěkná - vyšší kvalita, pomalejší
 options.graphics.tooltip.4=Mění vzhled mraků, listí, vody,
 options.graphics.tooltip.5=stínů a stran trávníků.
 
-of.options.renderDistance.tiny=Maličký
-of.options.renderDistance.short=Malý
-of.options.renderDistance.normal=Normální
-of.options.renderDistance.far=Velký
-of.options.renderDistance.extreme=Extrémní
-of.options.renderDistance.insane=Šílený
-of.options.renderDistance.ludicrous=Neuvěřitelný
- 
 options.renderDistance.tooltip.1=Dohled
-options.renderDistance.tooltip.2=  2 Maličký - 32m (nejrychlejší)
-options.renderDistance.tooltip.3=  8 Normální - 128m (normální)
-options.renderDistance.tooltip.4=  16 Velký - 256m (pomalejší)
-options.renderDistance.tooltip.5=  32 Extrémní - 512m (nejpomalejší!) velmi výkonově náročné
-options.renderDistance.tooltip.6=  48 Šílený - 768m, potřebuje 2 GB přidělené RAM
-options.renderDistance.tooltip.7=  64 Neuvěřitelný - 1024m,  potřebuje 3 GB přidělené RAM
-options.renderDistance.tooltip.8=Hodnoty nad 16 Velká jsou pouze pro lokální světy.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Vyhlazené stíny
 options.ao.tooltip.2=  NE - žádné vyhlazené osvětlení (rychlejší)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/de_de.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/de_de.lang
@@ -79,22 +79,9 @@ options.graphics.tooltip.3=  Schön   - Höhere Qualität (langsamer)
 options.graphics.tooltip.4=Verändert das Aussehen von Wolken, Blättern, Wasser,
 options.graphics.tooltip.5=Schatten und Grasblöcken.
 
-of.options.renderDistance.tiny=Winzig
-of.options.renderDistance.short=Klein
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Weit
-of.options.renderDistance.extreme=Extrem
-of.options.renderDistance.insane=Wahnsinnig
-of.options.renderDistance.ludicrous=Absurd
-
 options.renderDistance.tooltip.1=Sichtweite
-options.renderDistance.tooltip.2=  2 Winzig - 32m (am schnellsten)
-options.renderDistance.tooltip.3=  8 Normal - 128m
-options.renderDistance.tooltip.4=  16 Weit - 256m (langsam)
-options.renderDistance.tooltip.5=  32 Extrem - 512m (am langsamsten!) ressourcenlastig
-options.renderDistance.tooltip.6=  48 Wahnsinnig - 768m, braucht 2GB RAM zugeteilt
-options.renderDistance.tooltip.7=  64 Absurd - 1024m, braucht 3GB RAM zugeteilt
-options.renderDistance.tooltip.8=Werte über 16 funktionieren nur im Einzelspielermodus.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Weiche Beleuchtung
 options.ao.tooltip.2=  Aus - Normale Beleuchtung (schnell)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
@@ -75,21 +75,8 @@ options.graphics.tooltip.3=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥƃᴉɥ - ʎɔuɐ�
 options.graphics.tooltip.2='ɹǝʇɐʍ 'sǝʌɐǝꞁ 'spnoꞁɔ ɟo ǝɔuɐɹɐǝddɐ ǝɥʇ sǝƃuɐɥƆ
 options.graphics.tooltip.1=˙sǝpᴉs ssɐɹƃ puɐ sʍopɐɥs
 
-of.options.renderDistance.tiny=ʎuᴉ⟘
-of.options.renderDistance.short=ʇɹoɥS
-of.options.renderDistance.normal=ꞁɐɯɹoN
-of.options.renderDistance.far=ɹɐℲ
-of.options.renderDistance.extreme=ǝɯǝɹʇxƎ
-of.options.renderDistance.insane=ǝuɐsuI
-of.options.renderDistance.ludicrous=snoɹɔᴉpn˥
-
-options.renderDistance.tooltip.8=ǝɔuɐʇsᴉp ǝꞁqᴉsᴉΛ
-options.renderDistance.tooltip.7=(ʇsǝʇsɐɟ) ɯᘔƐ - ʎuᴉ⟘ ᘔ  
-options.renderDistance.tooltip.6=(ꞁɐɯɹou) ɯ8ᘔ⥝ - ꞁɐɯɹoN 8  
-options.renderDistance.tooltip.5=(ɹǝʍoꞁs) ɯ9ϛᘔ - ɹɐℲ 9⥝  
-options.renderDistance.tooltip.4=ƃuᴉpuɐɯǝp ǝɔɹnosǝɹ ʎɹǝʌ (¡ʇsǝʍoꞁs) ɯᘔ⥝ϛ - ǝɯǝɹʇxƎ ᘔƐ  
-options.renderDistance.tooltip.3=pǝʇɐɔoꞁꞁɐ W∀ɹ qפᘔ spǝǝu 'ɯ89ㄥ - ǝuɐsuI 8߈  
-options.renderDistance.tooltip.2=pǝʇɐɔoꞁꞁɐ W∀ɹ qפƐ spǝǝu 'ɯ߈ᘔ0⥝ - snoɹɔᴉpn˥ ߈9  
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
 options.renderDistance.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo ǝɹɐ ɹɐℲ 9⥝ ɹǝʌo sǝnꞁɐΛ
 
 options.ao.tooltip.4=ƃuᴉʇɥƃᴉꞁ ɥʇooɯS

--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_us.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_us.lang
@@ -73,22 +73,9 @@ options.graphics.tooltip.3=  Fancy - higher quality, slower
 options.graphics.tooltip.4=Changes the appearance of clouds, leaves, water,
 options.graphics.tooltip.5=shadows and grass sides.
 
-of.options.renderDistance.tiny=Tiny
-of.options.renderDistance.short=Short
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Far
-of.options.renderDistance.extreme=Extreme
-of.options.renderDistance.insane=Insane
-of.options.renderDistance.ludicrous=Ludicrous
-
 options.renderDistance.tooltip.1=Visible distance
-options.renderDistance.tooltip.2=  2 Tiny - 32m (fastest)
-options.renderDistance.tooltip.3=  8 Normal - 128m (normal)
-options.renderDistance.tooltip.4=  16 Far - 256m (slower)
-options.renderDistance.tooltip.5=  32 Extreme - 512m (slowest!) very resource demanding
-options.renderDistance.tooltip.6=  48 Insane - 768m, needs 2GB RAM allocated
-options.renderDistance.tooltip.7=  64 Ludicrous - 1024m, needs 3GB RAM allocated
-options.renderDistance.tooltip.8=Values over 16 Far are only effective in local worlds.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Smooth lighting
 options.ao.tooltip.2=  OFF - no smooth lighting (faster)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/es_mx.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/es_mx.lang
@@ -41,16 +41,9 @@ options.graphics.tooltip.3=  Detallada - Mejor apariencia.
 options.graphics.tooltip.4=Cambia la apariencia de nubes, hojas, agua,
 options.graphics.tooltip.5=sombras y bloques con pasto.
 
-of.options.renderDistance.extreme=Extremo
-
 options.renderDistance.tooltip.1=Distancia de renderizado.
-options.renderDistance.tooltip.2=  2 Mínimo - 32 bloques. (más rápido)
-options.renderDistance.tooltip.3=  4 Corto - 64 bloques.
-options.renderDistance.tooltip.4=  8 Normal - 128 bloques.
-options.renderDistance.tooltip.5=  16 Lejano - 256 bloques.
-options.renderDistance.tooltip.6=  32 Extremo - 512 bloques. (más lento)
-options.renderDistance.tooltip.7=La distancia de renderizado extrema demanda más recursos.
-options.renderDistance.tooltip.8=Valores sobre de 16 solo son efectivos en mundos locales.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Iluminación suave.
 options.ao.tooltip.2=  NO - Sin suavizado de iluminación. (rápido)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/et_ee.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/et_ee.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Uhke - kõrgem kvaliteet, aeglasem
 options.graphics.tooltip.4=Muudab pilvede, lehtede, vee, varjude ja muru külgede
 options.graphics.tooltip.5=välimust.
 
-of.options.renderDistance.tiny=pisike
-of.options.renderDistance.short=lühike
-of.options.renderDistance.normal=tavaline
-of.options.renderDistance.far=kauge
-of.options.renderDistance.extreme=ekstreemne
-of.options.renderDistance.insane=hullumeelne
-of.options.renderDistance.ludicrous=naeruväärne
-
 options.renderDistance.tooltip.1=Nähtav kaugus
-options.renderDistance.tooltip.2=  2 pisike - 32m (kiireim)
-options.renderDistance.tooltip.3=  8 tavaline - 128m (tavaline
-options.renderDistance.tooltip.4=  16 kauge - 256m (aeglasem)
-options.renderDistance.tooltip.5=  32 ekstreemne - 512m (aeglaseim!) väga ressursinõudlik
-options.renderDistance.tooltip.6=  48 hullumeelne - 768m, vajab 2 GB RAMi allutamist
-options.renderDistance.tooltip.7=  64 naeruväärne - 1024m, vajab 3 GB RAMi allutamist
-options.renderDistance.tooltip.8=Väärtused üle "16 kauge" toimivad ainult kohalikes maailmades.
+options.renderDistance.tooltip.2=  2-16 - tavaline nähtavuskaugus kõikidele maailmadele
+options.renderDistance.tooltip.3=  17-64 - ressursinõudlikud kaugused kohalikele maailmadele
 
 options.ao.tooltip.1=Sujuv valgustus
 options.ao.tooltip.2=  VÄLJAS - sujuv valgustus puudub (kiirem)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/fr_ca.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/fr_ca.lang
@@ -54,20 +54,9 @@ options.graphics.tooltip.3=  Détaillée - Haute qualité (Lent)
 options.graphics.tooltip.4=Change l'apparence des nuages, des feuilles, 
 options.graphics.tooltip.5=de l'eau, des ombres et du côté de l'herbe.
 
-of.options.renderDistance.tiny=Mini 
-of.options.renderDistance.short=Courte 
-of.options.renderDistance.normal=Normale 
-of.options.renderDistance.far=Loin 
-of.options.renderDistance.extreme=Extrême
-
 options.renderDistance.tooltip.1=Distance de Rendu 
-options.renderDistance.tooltip.2=  2 Mini - 32m (Très rapide) 
-options.renderDistance.tooltip.3=  4 courte - 64m (Rapide) 
-options.renderDistance.tooltip.4=  8 Normale - 128m 
-options.renderDistance.tooltip.5=  16 Loin - 256m (Lent) 
-options.renderDistance.tooltip.6=  32 Extrême - 512m (Très lent) 
-options.renderDistance.tooltip.7=La distance de rendu Extrême est très gourmande en ressources!
-options.renderDistance.tooltip.8=Les valeurs au-dessus de 16 n'ont effet qu'en solo.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Luminosité adoucie 
 options.ao.tooltip.2=  OFF - aucun adoucissement (rapide) 

--- a/OptiFineDoc/assets/minecraft/optifine/lang/fr_fr.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/fr_fr.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Détaillés - Haute qualité (lent)
 options.graphics.tooltip.4=Modifie l'apparence des nuages, des feuilles, de l'eau, des
 options.graphics.tooltip.5=ombres et du côté de l'herbe.
 
-of.options.renderDistance.tiny=Minimale
-of.options.renderDistance.short=Courte
-of.options.renderDistance.normal=Normale
-of.options.renderDistance.far=Lointaine
-of.options.renderDistance.extreme=Extrême
-of.options.renderDistance.insane=Insensée
-of.options.renderDistance.ludicrous=Inimaginable
-
 options.renderDistance.tooltip.1=Distance d'affichage
-options.renderDistance.tooltip.2=  2 Mini - 32m (très rapide)
-options.renderDistance.tooltip.3=  8 Normale - 128m (normal)
-options.renderDistance.tooltip.4=  16 Loin - 256m (lent)
-options.renderDistance.tooltip.5=  32 Extrême - 512m (très lent) - Très gourmand en ressources
-options.renderDistance.tooltip.6=  48 Insensée - 768m, nécessite 2 Go de RAM allouée
-options.renderDistance.tooltip.7=  64 Inimaginable - 1024m, nécessite 3 Go de RAM allouée
-options.renderDistance.tooltip.8=Les valeurs au-dessus de 16 n'ont effet qu'en solo.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Luminosité adoucie
 options.ao.tooltip.2=  Non - aucun adoucissement (rapide)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/hu_hu.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/hu_hu.lang
@@ -50,20 +50,9 @@ options.graphics.tooltip.3=  Szép - magasabb minőség, lassabb
 options.graphics.tooltip.4=Megváltoztatja a megjelenését a felhőknek, leveleknek, víznek,
 options.graphics.tooltip.5=árnyékoknak és a fű oldalainak.
 
-of.options.renderDistance.tiny=Apró
-of.options.renderDistance.short=Rövid
-of.options.renderDistance.normal=Normál
-of.options.renderDistance.far=Messzi
-of.options.renderDistance.extreme=Extrém
-
 options.renderDistance.tooltip.1=Látótávolság
-options.renderDistance.tooltip.2=  2 Apró - 32m (leggyorsabb)
-options.renderDistance.tooltip.3=  4 Rövid - 64m (gyorsabb)
-options.renderDistance.tooltip.4=  8 Normál - 128m
-options.renderDistance.tooltip.5=  16 Messzi - 256m (lassabb)
-options.renderDistance.tooltip.6=  32 Extrém - 512m (leglassab!)
-options.renderDistance.tooltip.7=Az Extrém látótávolság nagyon erőforrás igényes!
-options.renderDistance.tooltip.8=Értékek 16 Messzi fölött csak helyi világokban effektív.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Simított megvilágítás
 options.ao.tooltip.2=  KI - Nincs simított megvilágítás (gyorsabb)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/it_it.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/it_it.lang
@@ -59,22 +59,9 @@ options.graphics.tooltip.3=  Dettagliata - qualità migliore, prestazioni peggio
 options.graphics.tooltip.4=Cambiamenti visibili nelle nuvole, foglie, acqua
 options.graphics.tooltip.5=ombre e lati dei blocchi d'erba.
 
-of.options.renderDistance.tiny=Minima
-of.options.renderDistance.short=Corta
-of.options.renderDistance.normal=Normale
-of.options.renderDistance.far=Lontana
-of.options.renderDistance.extreme=Estrema
-of.options.renderDistance.insane=Folle
-of.options.renderDistance.ludicrous=Ridicola
-
 options.renderDistance.tooltip.1=Distanza visibile
-options.renderDistance.tooltip.2=  2 Minima - 32m (più veloce)
-options.renderDistance.tooltip.3=  8 Normale - 128m (normale)
-options.renderDistance.tooltip.4=  16 Lontana - 256m (lenta)
-options.renderDistance.tooltip.5=  32 Estrema - 512m (molto lenta!) richiede molte risorse
-options.renderDistance.tooltip.6=  48 Folle - 768m, richiede 2GB di RAM allocati
-options.renderDistance.tooltip.7=  64 Ridicola - 1024m, richiede 3GB di RAM allocati
-options.renderDistance.tooltip.8=Valori sopra 16 sono funzionanti solo in mondi locali.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Luci soffuse
 options.ao.tooltip.2=  No - senza luci soffuse (veloce)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/ja_jp.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/ja_jp.lang
@@ -65,22 +65,9 @@ options.graphics.tooltip.3=  描画優先 - 高品質、高負荷
 options.graphics.tooltip.4=葉の透過、アイテムやMobの影、ドロップアイテムの3D描写、
 options.graphics.tooltip.5=厚みのある雲、水の2パスレンダリング、といったグラフィック効果を変更します。
 
-of.options.renderDistance.tiny=最短
-of.options.renderDistance.short=短い
-of.options.renderDistance.normal=普通
-of.options.renderDistance.far=遠い
-of.options.renderDistance.extreme=過激
-of.options.renderDistance.insane=狂気
-of.options.renderDistance.ludicrous=不条理
-
 options.renderDistance.tooltip.1=描画距離
-options.renderDistance.tooltip.2=  2 最短 - 32m (最低負荷)
-options.renderDistance.tooltip.3=  8 普通 - 128m (普通)
-options.renderDistance.tooltip.4=  16 遠い - 256m (高負荷)
-options.renderDistance.tooltip.5=  32 過激 - 512m (超高負荷！) 大量のリソースを要求します
-options.renderDistance.tooltip.6=  48 狂気 - 768m、2GBのメモリー割り当てが必要です
-options.renderDistance.tooltip.7=  64 不条理 - 1024m、3GBのメモリー割り当てが必要です
-options.renderDistance.tooltip.8=遠いを超える描画距離はシングルのワールドでのみ効果があります。
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=スムースライティング
 options.ao.tooltip.2=  オフ - スムースライティングを使用しない (低負荷)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/ko_kr.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/ko_kr.lang
@@ -57,20 +57,9 @@ options.graphics.tooltip.3=  화려하게 - 높은 품질, 느림
 options.graphics.tooltip.4=구름, 잎, 물, 그림자, 풀의
 options.graphics.tooltip.5=외형을 변경합니다.
 
-of.options.renderDistance.tiny=아주 작게
-of.options.renderDistance.short=짧게
-of.options.renderDistance.normal=보통
-of.options.renderDistance.far=멀리
-of.options.renderDistance.extreme=극도
-
 options.renderDistance.tooltip.1=시야 거리
-options.renderDistance.tooltip.2=  2 아주 작게 - 32m (가장 빠름)
-options.renderDistance.tooltip.3=  4 짧게 - 64m (빠름)
-options.renderDistance.tooltip.4=  8 보통 - 128m
-options.renderDistance.tooltip.5=  16 멀리 - 256m (느림)
-options.renderDistance.tooltip.6=  32 극도 - 512m (가장 느림!)
-options.renderDistance.tooltip.7=극도 시야 거리는 상당한 성능이 요구됩니다!
-options.renderDistance.tooltip.8=16 멀리를 넘는 값은 로컬 세계에서만 효과가 있습니다.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=부드러운 조명 효과
 options.ao.tooltip.2=  꺼짐 - 부드러운 조명 효과 없음 (빠름)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/lb_lu.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/lb_lu.lang
@@ -62,22 +62,9 @@ options.graphics.tooltip.3=  Schéin - héich Qualitéit, méi lues
 options.graphics.tooltip.4=Verännert d'Ausgesi vun de Wolleken, Blieder, Grasbléck,
 options.graphics.tooltip.5=Schieter a vum Waasser.
 
-of.options.renderDistance.tiny=Winzeg
-of.options.renderDistance.short=Geréng
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Wéit
-of.options.renderDistance.extreme=Extrem
-of.options.renderDistance.insane=Verréckt
-of.options.renderDistance.ludicrous=Wahnsinn
-
 options.renderDistance.tooltip.1=Siichtwéit
-options.renderDistance.tooltip.2=  2 Winzeg - 32m (am schnellsten)
-options.renderDistance.tooltip.3=  8 Normal - 128m (normal)
-options.renderDistance.tooltip.4=  16 Wéit - 256m (lues)
-options.renderDistance.tooltip.5=  32 Extrem - 512m (am luesten!) brauch vill Ressourcen
-options.renderDistance.tooltip.6=  48 Verréckt - 768m, brauch 2GB RAM zougedeelt
-options.renderDistance.tooltip.7=  64 Wahnsinn - 1024m, brauch 3GB RAM zougedeelt
-options.renderDistance.tooltip.8=Wäerter iwwer 16 funktionéieren nëmmen am Singleplayer.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Fléissend Beliichtung
 options.ao.tooltip.2=  Aus - keng fléissend Beliichtung (schnell)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/nl_nl.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/nl_nl.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Fraai - hogere kwaliteit, langzamer
 options.graphics.tooltip.4=Verandert hoe wolken, bladeren, water,
 options.graphics.tooltip.5=schaduwen and gras eruit ziet.
 
-of.options.renderDistance.tiny=Klein
-of.options.renderDistance.short=Kort
-of.options.renderDistance.normal=Normaal
-of.options.renderDistance.far=Ver
-of.options.renderDistance.extreme=Extreem
-of.options.renderDistance.insane=Krankzinnig
-of.options.renderDistance.ludicrous=Belachelijk
-
 options.renderDistance.tooltip.1=Zichtbare Afstand
-options.renderDistance.tooltip.2=  2 Klein - 32m (snelste)
-options.renderDistance.tooltip.3=  8 Normaal - 128m (normaal)
-options.renderDistance.tooltip.4=  16 Ver - 256m (langzamer)
-options.renderDistance.tooltip.5=  32 Extreem - 512m (langzaamste!) erg veeleisend
-options.renderDistance.tooltip.6=  48 Krankzinnig - 768m, 2GB toegewezen RAM benodigd
-options.renderDistance.tooltip.7=  64 Belachelijk - 1024m, 3GB toegewezen RAM benodigd
-options.renderDistance.tooltip.8=Waarden boven de 16 (Ver) zijn alleen effectief in locale werelden.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Zachte Verlichting
 options.ao.tooltip.2=  UIT - geen zachte verlichting (sneller)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/no_no.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/no_no.lang
@@ -76,22 +76,9 @@ options.graphics.tooltip.3=  Stilig - høyere kvalitet, langsommere
 options.graphics.tooltip.4=Endrer utseendet på skyer, blader, vann, skygger og
 options.graphics.tooltip.5=gresskanter.
 
-of.options.renderDistance.tiny=Liten
-of.options.renderDistance.short=Kort
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Lang
-of.options.renderDistance.extreme=Ekstrem
-of.options.renderDistance.insane=Sinnssyk
-of.options.renderDistance.ludicrous=Latterlig
-
 options.renderDistance.tooltip.1=Synlig avstand
-options.renderDistance.tooltip.2=   2 Liten - 32m (raskeste)
-options.renderDistance.tooltip.3=   8 Normal - 128m (normal)
-options.renderDistance.tooltip.4=  16 Lang - 256m (langsommere)
-options.renderDistance.tooltip.5=  32 Ekstrem - 512m (langsomste!) veldig ressurskrevende
-options.renderDistance.tooltip.6=  48 Sinnssyk - 768m, trenger 2 GB tildelt RAM
-options.renderDistance.tooltip.7=  64 Latterlig - 1024m, trenger 3 GB tildelt RAM
-options.renderDistance.tooltip.8=Verdier over 16 er bare effektive i lokale verdener.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Jevnt beslysningsnivå
 options.ao.tooltip.2=  AV - ingen jevn beslysning (hurtigste)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/pl_pl.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/pl_pl.lang
@@ -65,22 +65,9 @@ options.graphics.tooltip.3=  Dokładna - wyższa jakość, mniejsza wydajność
 options.graphics.tooltip.4=Zmienia wygląd chmur, liści, wody,
 options.graphics.tooltip.5=cieni oraz boków bloków trawy.
 
-of.options.renderDistance.tiny=Najkrótsza
-of.options.renderDistance.short=Krótka
-of.options.renderDistance.normal=Normalna
-of.options.renderDistance.far=Długa
-of.options.renderDistance.extreme=Ekstremalna
-of.options.renderDistance.insane=Szalona
-of.options.renderDistance.ludicrous=Niedorzeczna
-
 options.renderDistance.tooltip.1=Odległość renderowania
-options.renderDistance.tooltip.2=  2 Najkrótsza - 32m
-options.renderDistance.tooltip.3=  8 Normalna - 128m
-options.renderDistance.tooltip.4=  16 Długa - 256m
-options.renderDistance.tooltip.5=  32 Ekstremalna - 512m
-options.renderDistance.tooltip.6=  48 Szalona - 768m, potrzeba min. 2GB RAMu
-options.renderDistance.tooltip.7=  64 Niedorzeczna - 1024m, potrzeba min. 3GB RAMu
-options.renderDistance.tooltip.8=Wartości powyżej 16 są zalecane tylko dla lokalnych światów.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Gładkie oświetlenie
 options.ao.tooltip.2=  Wył. - brak wygładzania oświetlenia (wysoka wydajność)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/pt_br.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/pt_br.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Detalhados - alta qualidade
 options.graphics.tooltip.4=Muda a aparência de nuvens, folhas, água,
 options.graphics.tooltip.5=sombras e grama.
 
-of.options.renderDistance.tiny=Mínima
-of.options.renderDistance.short=Curta
-of.options.renderDistance.normal=Padrão
-of.options.renderDistance.far=Longa
-of.options.renderDistance.extreme=Extrema
-of.options.renderDistance.insane=Insana
-of.options.renderDistance.ludicrous=Máxima
-
 options.renderDistance.tooltip.1=Distância visível
-options.renderDistance.tooltip.2=  2 Mínima - 32m (mais rápido)
-options.renderDistance.tooltip.3=  8 Padrão - 128m (normal)
-options.renderDistance.tooltip.4=  16 Longa - 256m (lento)
-options.renderDistance.tooltip.5=  32 Extrema - 512m (mais lento)
-options.renderDistance.tooltip.6=  48 Insana - 768m (requer 2GB de RAM)
-options.renderDistance.tooltip.7=  64 Máxima - 1024m (requer 3GB de RAM)
-options.renderDistance.tooltip.8=Valores acima de 16 funcionam apenas em mundos locais.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Iluminação suave
 options.ao.tooltip.2=  Não - iluminação comum (rápido)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/pt_pt.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/pt_pt.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Elegante - maior qualidade, lento
 options.graphics.tooltip.4=Altera a aparência das nuvens, folhas, água,
 options.graphics.tooltip.5=sombras e ainda as laterais da relva.
 
-of.options.renderDistance.tiny=Minúscula
-of.options.renderDistance.short=Curta
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Longa
-of.options.renderDistance.extreme=Extrema
-of.options.renderDistance.insane=Insana
-of.options.renderDistance.ludicrous=Ridícula
-
 options.renderDistance.tooltip.1=Alcance visual
-options.renderDistance.tooltip.2=  2 Minúscula - 32m (rápida)
-options.renderDistance.tooltip.3=  8 Normal - 128m (normal)
-options.renderDistance.tooltip.4=  16 Longa - 256m (lenta)
-options.renderDistance.tooltip.5=  32 Extrema - 512m (muito lenta) exige muitos recursos
-options.renderDistance.tooltip.6=  48 Insana - 768m, precisas de 2GB de RAM
-options.renderDistance.tooltip.7=  64 Ridícula - 1024m, precisas de 3GB de RAM
-options.renderDistance.tooltip.8=Valores acima de 16 só serão eficazes em mundos locais.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Iluminação suave
 options.ao.tooltip.2=  Não - sem iluminação suave (rápida)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/ro_ro.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/ro_ro.lang
@@ -57,22 +57,9 @@ options.graphics.tooltip.3=  Atractiv - calitate mare, lent
 options.graphics.tooltip.4=Schimba aspectul norilor, frunzelor, apei,
 options.graphics.tooltip.5=umbrelor si fetele ierbii.
 
-of.options.renderDistance.tiny=Mic
-of.options.renderDistance.short=Scurt
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Departe
-of.options.renderDistance.extreme=Extrem
-of.options.renderDistance.insane=Nebun
-of.options.renderDistance.ludicrous=Ridicol
-
 options.renderDistance.tooltip.1=Distanta vizibila
-options.renderDistance.tooltip.2=  2 Mic - 32m (rapid)
-options.renderDistance.tooltip.3=  4 Scurt - 64m (rapid)
-options.renderDistance.tooltip.4=  8 Normal - 128m
-options.renderDistance.tooltip.5=  16 Departe - 256m (lent)
-options.renderDistance.tooltip.6=  32 Extrem - 512m (foarte lent!)
-options.renderDistance.tooltip.7=Vederea la distanta Extrem este foarte solicitant pentru resurse!
-options.renderDistance.tooltip.8=Valorile peste 16 Departe are efect doar intr-o lume locala.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Lumina neteda
 options.ao.tooltip.2=  OPRIT - fara lumina neteda (rapid)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/ru_ru.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/ru_ru.lang
@@ -76,21 +76,8 @@ options.graphics.tooltip.4=Изменяет облик дёрна, листье�
 options.graphics.tooltip.5=
 
 options.renderDistance.tooltip.1=Дальность прорисовки
-options.renderDistance.tooltip.2=  2 Минимальная - 32 м (ещё быстрее)
-options.renderDistance.tooltip.3=  4 Малая - 64 м (быстрее)
-options.renderDistance.tooltip.4=  8 Нормальная - 128 м
-options.renderDistance.tooltip.5=  16 Дальняя - 256 м (медленнее)
-options.renderDistance.tooltip.6=  32 Предельная - 512 м (ещё медленнее!)
-options.renderDistance.tooltip.7=  48 Безумная - 768 м, требуется 2 Гбайт ОЗУ
-options.renderDistance.tooltip.8=  64 Абсурдная! - 1024 м, требуется 3 Гбайт ОЗУ
-
-of.options.renderDistance.tiny=Минимальная
-of.options.renderDistance.short=Малая
-of.options.renderDistance.normal=Нормальная
-of.options.renderDistance.far=Дальняя
-of.options.renderDistance.extreme=Предельная
-of.options.renderDistance.insane=Безумная
-of.options.renderDistance.ludicrous=Абсурдная!
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Мягкое освещение
 options.ao.tooltip.2=  Выкл - без мягкого освещения (быстрее)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/sk_sk.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/sk_sk.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Pekná - vyššia kvalita, pomalšia
 options.graphics.tooltip.4=Mení vzhľad oblakov, listov, vody,
 options.graphics.tooltip.5=tieňov a trávy.
 
-of.options.renderDistance.tiny=Drobná
-of.options.renderDistance.short=Krátka
-of.options.renderDistance.normal=Normálna
-of.options.renderDistance.far=Ďaleká
-of.options.renderDistance.extreme=Extrémna
-of.options.renderDistance.insane=Šialená
-of.options.renderDistance.ludicrous=Absurdná
-
 options.renderDistance.tooltip.1=Dohľadnosť (vzdialenosť vykresľovania)
-options.renderDistance.tooltip.2=  2 Drobná - 32m (najrýchlejšia)
-options.renderDistance.tooltip.3=  8 Normálna - 128m (normálna)
-options.renderDistance.tooltip.4=  16 Ďaleká - 256m (pomalšia)
-options.renderDistance.tooltip.5=  32 Extrémna - 512m (najpomalšia!) veľmi náročná na výkon
-options.renderDistance.tooltip.6=  48 Šialená - 768m, potrebuje 2GB alokovanej RAM
-options.renderDistance.tooltip.7=  64 Absurdná - 1024m, potrebuje 3GB alokovanej RAM
-options.renderDistance.tooltip.8=Hodnoty nad 16 sú funkčné len pre lokálne svety.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Vyhladené osvetlenie
 options.ao.tooltip.2=  VYP - žiadne vyhladené osvetlenie (rýchlejšie)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/sv_se.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/sv_se.lang
@@ -74,22 +74,9 @@ options.graphics.tooltip.3=  Snyggt - högre kvalitet, långsammare
 options.graphics.tooltip.4=Ändrar utseendet för moln, löv, vatten, skuggor och
 options.graphics.tooltip.5=gräskanter.
 
-of.options.renderDistance.tiny=Litet
-of.options.renderDistance.short=Kort
-of.options.renderDistance.normal=Normalt
-of.options.renderDistance.far=Långt
-of.options.renderDistance.extreme=Extremt
-of.options.renderDistance.insane=Galet
-of.options.renderDistance.ludicrous=Löjligt
-
 options.renderDistance.tooltip.1=Synligt avstånd
-options.renderDistance.tooltip.2=   2 Litet - 32m (snabbast)
-options.renderDistance.tooltip.3=   8 Normalt - 128m (normalt)
-options.renderDistance.tooltip.4=  16 Långt - 256m (långsammare)
-options.renderDistance.tooltip.5=  32 Extremt - 512m (långsammast!) mkt resurskrävande
-options.renderDistance.tooltip.6=  48 Galet - 768m, behöver 2GB allokerat RAM
-options.renderDistance.tooltip.7=  64 Löjligt - 1024m, behöver 3GB allokerat RAM
-options.renderDistance.tooltip.8=Värden över 16 fungerar endast i lokala världar.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Ljusutjämning
 options.ao.tooltip.2=  AV - ingen ljusutjämning (snabbast)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/tr_tr.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/tr_tr.lang
@@ -71,22 +71,9 @@ options.graphics.tooltip.3=  Efsane - yüksek kalite, yavaş oyun deneyimi
 options.graphics.tooltip.4=Ayarlar bulutlar, yapraklar, suya
 options.graphics.tooltip.5=gölgeler ve çim yüzerlerine etki edecektir.
 
-of.options.renderDistance.tiny=Düşük
-of.options.renderDistance.short=Kısa
-of.options.renderDistance.normal=Normal
-of.options.renderDistance.far=Uzak
-of.options.renderDistance.extreme=Yüksek
-of.options.renderDistance.insane=Efsane
-of.options.renderDistance.ludicrous=Olağanüstü
-
 options.renderDistance.tooltip.1=Görüş uzaklığı
-options.renderDistance.tooltip.2=  2 Düşük - 32m (en hızlı)
-options.renderDistance.tooltip.3=  8 Normal - 128m (varsayılan)
-options.renderDistance.tooltip.4=  16 Uzak - 256m (daha yavaş)
-options.renderDistance.tooltip.5=  32 Yüksek - 512m (çok yavaş!) çok kaynak tüketir
-options.renderDistance.tooltip.6=  48 Efsane - 768m, min 2G ram verilmiş olması gerekir
-options.renderDistance.tooltip.7=  64 Olağanüstü - 1024m, minimum 3 g ram gerektirir
-options.renderDistance.tooltip.8=16 üstündeki değerler sadece tek oyunculuda geçerlidir.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=Gerçekçi aydınlatma
 options.ao.tooltip.2=  Kapalı - Gerçekçi aydınlatma kapalı (hızlı)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/uk_ua.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/uk_ua.lang
@@ -72,22 +72,9 @@ options.graphics.tooltip.3=  Красива - висока якість, пов�
 options.graphics.tooltip.4=Змінює зовнішній вигляд хмар, листя води
 options.graphics.tooltip.5=тіней і сторін трави.
 
-of.options.renderDistance.tiny=Маленька
-of.options.renderDistance.short=Коротка
-of.options.renderDistance.normal=Нормальна
-of.options.renderDistance.far=Далека
-of.options.renderDistance.extreme=Екстремальна
-of.options.renderDistance.insane=Шалена
-of.options.renderDistance.ludicrous=Безглузда!
-
 options.renderDistance.tooltip.1=Видима відстань
-options.renderDistance.tooltip.2=  2 Маленька - 32м (найшвидше)
-options.renderDistance.tooltip.3=  8 Нормальна - 128м (нормальна)
-options.renderDistance.tooltip.4=  16 Далека - 256м (повільніше)
-options.renderDistance.tooltip.5=  32 Надзвичайна - 512м (найповільніше!) потребує багато ресурсів
-options.renderDistance.tooltip.6=  48 Шалена - 768m, потребує 2GB оперативної пам'яті
-options.renderDistance.tooltip.7=  64 Безглузда - 1024m, потребує 3GB оперативної пам'яті
-options.renderDistance.tooltip.8=  Значення більше ніж 16 ефективні лише для локальних світів.
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=М'яке освітлення
 options.ao.tooltip.2=  Вимк - без м'якого освітлення (Швидка)

--- a/OptiFineDoc/assets/minecraft/optifine/lang/zh_cn.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/zh_cn.lang
@@ -82,22 +82,9 @@ options.graphics.tooltip.3=  高品质 - 高品质（较慢）
 options.graphics.tooltip.4=改变云、树叶、水、
 options.graphics.tooltip.5=阴影和草地的外观。
 
-of.options.renderDistance.tiny=最近
-of.options.renderDistance.short=近
-of.options.renderDistance.normal=中等
-of.options.renderDistance.far=远
-of.options.renderDistance.extreme=极远
-of.options.renderDistance.insane=疯狂
-of.options.renderDistance.ludicrous=荒唐
-
 options.renderDistance.tooltip.1=能见度
-options.renderDistance.tooltip.2=  2 最近 - 32m（最快）
-options.renderDistance.tooltip.3=  8 中等 - 128m（正常）
-options.renderDistance.tooltip.4=  16 远 - 256m（较慢）
-options.renderDistance.tooltip.5=  32 极远 - 512m（最慢！）非常消耗资源！
-options.renderDistance.tooltip.6=  48 疯狂 - 768m，需要2G的内存分配
-options.renderDistance.tooltip.7=  64 荒唐 - 1024m，需要3G的内存分配
-options.renderDistance.tooltip.8=超过 16 的能见度值只在本地世界有效。
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=平滑光照
 options.ao.tooltip.2=  关闭 - 禁用平滑光照（较快）

--- a/OptiFineDoc/assets/minecraft/optifine/lang/zh_tw.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/zh_tw.lang
@@ -67,22 +67,9 @@ options.graphics.tooltip.3=  精緻  - 高畫質，較慢
 options.graphics.tooltip.4=改變雲、樹葉、水、
 options.graphics.tooltip.5=陰影與草地側面的外觀。
 
-of.options.renderDistance.tiny=最近
-of.options.renderDistance.short=近
-of.options.renderDistance.normal=中等
-of.options.renderDistance.far=遠
-of.options.renderDistance.extreme=超遠
-of.options.renderDistance.insane=病態
-of.options.renderDistance.ludicrous=荒唐
-
 options.renderDistance.tooltip.1=視野距離
-options.renderDistance.tooltip.2=  2 最近 - 32m（最快）
-options.renderDistance.tooltip.3=  8 中等 - 128m（正常）
-options.renderDistance.tooltip.4=  16 遠 - 256m（較慢）
-options.renderDistance.tooltip.5=  32 超遠 - 512m（最慢！）非常消耗資源！
-options.renderDistance.tooltip.6=  48 病態 - 768m，需要分配 2G 的記憶體
-options.renderDistance.tooltip.7=  64 荒唐 - 1024m，需要分配 3G 的記憶體
-options.renderDistance.tooltip.8=16 以上的視野值只在本機世界有效。
+options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
+options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
 
 options.ao.tooltip.1=柔和光源
 options.ao.tooltip.2=  關閉 - 無柔和光源（較快）


### PR DESCRIPTION
Replaces
```
options.renderDistance.tooltip.1=Visible distance
options.renderDistance.tooltip.2=  2 Tiny - 32m (fastest)
options.renderDistance.tooltip.3=  8 Normal - 128m (normal)
options.renderDistance.tooltip.4=  16 Far - 256m (slower)
options.renderDistance.tooltip.5=  32 Extreme - 512m (slowest!) very resource demanding
options.renderDistance.tooltip.6=  48 Insane - 768m, needs 2GB RAM allocated
options.renderDistance.tooltip.7=  64 Ludicrous - 1024m, needs 3GB RAM allocated
options.renderDistance.tooltip.8=Values over 16 Far are only effective in local worlds.
```
with
```
options.renderDistance.tooltip.1=Visible distance
options.renderDistance.tooltip.2=  2-16 - normal render distances for all worlds
options.renderDistance.tooltip.3=  17-64 - resource demanding distances for local worlds
```
and removes
```
of.options.renderDistance.tiny=Tiny
of.options.renderDistance.short=Short
of.options.renderDistance.normal=Normal
of.options.renderDistance.far=Far
of.options.renderDistance.extreme=Extreme
of.options.renderDistance.insane=Insane
of.options.renderDistance.ludicrous=Ludicrous
```
on all languages.

