### PR TITLE
Added 'head' bone to Dolphin, fixed Skeleton horse bone list.

### DIFF
--- a/OptiFineDoc/doc/cem_model.txt
+++ b/OptiFineDoc/doc/cem_model.txt
@@ -51,7 +51,7 @@
 # horse                body, neck, back_left_leg, back_right_leg, front_left_leg, front_right_leg, tail, saddle,
 #                      head, mane, mouth, left_ear, right_ear, left_bit, right_bit, left_rein, right_rein, headpiece, noseband,
 #                      child_back_left_leg, child_back_right_leg, child_front_left_leg, child_front_right_leg
-# illusioner           head, body, arms, left_leg, right_leg, nose, left_arm, right_arm
+# illusioner           head, hat, body, arms, left_leg, right_leg, nose, left_arm, right_arm
 # iron_golem           head, body, left_arm, right_arm, left_leg, right_leg
 # lead_knot            knot
 # llama                head, body, leg1 ... leg4, chest_right, chest_left

--- a/OptiFineDoc/doc/cem_model.txt
+++ b/OptiFineDoc/doc/cem_model.txt
@@ -32,7 +32,7 @@
 # creeper              head, armor, body, leg1 ... leg4
 # dragon               head, spine, jaw, body, rear_leg, front_leg, rear_leg_tip, front_leg_tip, rear_foot, front_foot, wing, wing_tip
 # donkey               <same as horse>
-# dolphin              body, back_fin, left_fin, right_fin, tail
+# dolphin              head, body, back_fin, left_fin, right_fin, tail
 # drowned              head, headwear, body, left_arm, right_arm, left_leg, right_leg
 # ender_chest          lid, base, knob
 # end_crystal          cube, glass, base
@@ -82,7 +82,9 @@
 # sign                 board, stick
 # silverfish           body1 ... body7, wing1 ... wing3
 # skeleton             head, headwear, body, left_arm, right_arm, left_leg, right_leg
-# skeleton_horse       <same as horse>
+# skeleton_horse       body, neck, back_left_leg, back_right_leg, front_left_leg, front_right_leg, saddle,
+#                      head, mane, mouth, left_bit, right_bit, left_rein, right_rein, headpiece, noseband,
+#                      child_back_left_leg, child_back_right_leg, child_front_left_leg, child_front_right_leg
 # slime                body, left_eye, right_eye, mouth
 # snow_golem           body, body_bottom, head, left_hand, right_hand
 # spawner_minecart     bottom, back, front, right, left, dirt


### PR DESCRIPTION
Added a missing bone called 'head' to the Dolphin. The dolphin is still missing one more bone but we don't know its name. Added a missing bone called 'hat' to the Illusioner. Fixed Skeleton horse bone list (it included bones that don't exist for it so it wouldn't load).