### PR TITLE
Update en_ud.lang

### DIFF
--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
@@ -43,14 +43,14 @@ of.message.shaders.gf1=˙ʎɔuɐℲ ɹo ʇsɐℲ oʇ sɔᴉɥdɐɹ⅁ ʇǝs ǝs�
 of.message.shaders.an2=˙ɥdʎꞁᵷɐuⱯ ᗡƐ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
 of.message.shaders.an1=˙ℲℲO oʇ ɥdʎꞁᵷɐuⱯ ᗡƐ <- ɹǝɥʇO ʇǝs ǝsɐǝꞁԀ
 
-of.message.shaders.nv2=%1$s :uoᴉsɹǝʌ ǝuᴉℲᴉʇdO ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
+of.message.shaders.nv2=%s :uoᴉsɹǝʌ ǝuᴉℲᴉʇdO ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
 of.message.shaders.nv1=¿ǝnuᴉʇuoɔ oʇ ʇuɐʍ noʎ ǝɹns noʎ ǝɹⱯ
 
-of.message.newVersion=§f%1$s§e :ǝꞁqɐꞁᴉɐʌɐ sᴉ uoᴉsɹǝʌ §fǝuᴉℲᴉʇdO§e ʍǝu Ɐ
-of.message.java64Bit=˙ǝɔuɐɯɹoɟɹǝd ǝsɐǝɹɔuᴉ oʇ §fɐʌɐſ ʇᴉq-߈9§e ꞁꞁɐʇsuᴉ uɐɔ no⅄
-of.message.openglError=(%2$s) %1$s :§fɹoɹɹƎ Ꞁ⅁uǝdO§e
+of.message.newVersion=§f§e%s§f :ǝꞁqɐꞁᴉɐʌɐ sᴉ uoᴉsɹǝʌ §eǝuᴉℲᴉʇdO§r ʍǝu Ɐ
+of.message.java64Bit=§f˙ǝɔuɐɯɹoɟɹǝd ǝsɐǝɹɔuᴉ oʇ §eɐʌɐſ ʇᴉq-߈9§r ꞁꞁɐʇsuᴉ uɐɔ no⅄
+of.message.openglError=§f(%2$s) %1$s :§eɹoɹɹƎ Ꞁ⅁uǝdO
 
-of.message.shaders.loading=%1$s :sɹǝpɐɥs ᵷuᴉpɐoꞀ
+of.message.shaders.loading=%s :sɹǝpɐɥs ᵷuᴉpɐoꞀ
 
 of.message.other.reset=¿sǝnꞁɐʌ ʇꞁnɐɟǝp ɹᴉǝɥʇ oʇ sᵷuᴉʇʇǝs oǝpᴉʌ ꞁꞁɐ ʇǝsǝᴚ
 
@@ -70,7 +70,7 @@ of.message.capeOF.openEditorError=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ ʞuᴉꞁ ɹoʇᴉ
 of.message.capeOF.reloadCape=˙spuoɔǝs ϛ⥝ uᴉ pǝpɐoꞁǝɹ ǝq ꞁꞁᴉʍ ǝdɐɔ ǝɥ⟘
 
 of.message.capeOF.error2=˙pǝꞁᴉɐɟ uoᴉʇɐɔᴉʇuǝɥʇnɐ ᵷuɐɾoW
-of.message.capeOF.error1=%1$s :ɹoɹɹƎ
+of.message.capeOF.error1=%s :ɹoɹɹƎ
 
 # Video settings
 

--- a/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
+++ b/OptiFineDoc/assets/minecraft/optifine/lang/en_ud.lang
@@ -22,32 +22,35 @@ of.message.aa.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐ
 of.message.af.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ᵷuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉuⱯ
 of.message.af.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
 
-of.message.fr.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɹǝpuǝɹ ʇsɐℲ
+of.message.fr.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɹǝpuǝᴚ ʇsɐℲ
 of.message.fr.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
 
-of.message.an.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɥdʎꞁᵷɐuⱯ pƐ
+of.message.an.shaders2=˙sɹǝpɐɥS ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ ɥdʎꞁᵷɐuⱯ ᗡƐ
 of.message.an.shaders1=˙uoᴉʇdo sᴉɥʇ ǝꞁqɐuǝ oʇ sɹǝpɐɥS ǝꞁqɐsᴉp ǝsɐǝꞁԀ
 
 of.message.shaders.aa2=˙ᵷuᴉsɐᴉꞁɐᴉʇuⱯ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.aa1=˙ǝɯɐᵷ ǝɥʇ ʇɹɐʇsǝɹ puɐ ℲℲO oʇ ᵷuᴉsɐᴉꞁɐᴉʇuⱯ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.aa1=˙ǝɯɐᵷ ǝɥʇ ʇɹɐʇsǝɹ puɐ ℲℲO oʇ ᵷuᴉsɐᴉꞁɐᴉʇuⱯ <- ʎʇᴉꞁɐnꝹ ʇǝs ǝsɐǝꞁԀ
 
 of.message.shaders.af2=˙ᵷuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉuⱯ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.af1=˙ℲℲO oʇ ᵷuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉuⱯ <- ʎʇᴉꞁɐnQ ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.af1=˙ℲℲO oʇ ᵷuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉuⱯ <- ʎʇᴉꞁɐnꝹ ʇǝs ǝsɐǝꞁԀ
 
-of.message.shaders.fr2=˙ɹǝpuǝɹ ʇsɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.fr1=˙ℲℲO oʇ ɹǝpuǝɹ ʇsɐℲ <- ǝɔuɐɯɹoɟɹǝԀ ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.fr2=˙ɹǝpuǝᴚ ʇsɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.fr1=˙ℲℲO oʇ ɹǝpuǝᴚ ʇsɐℲ <- ǝɔuɐɯɹoɟɹǝԀ ʇǝs ǝsɐǝꞁԀ
 
-of.message.shaders.an2=˙ɥdʎꞁᵷɐuⱯ pƐ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
-of.message.shaders.an1=˙ℲℲO oʇ ɥdʎꞁᵷɐuⱯ pƐ <- ɹǝɥʇo ʇǝs ǝsɐǝꞁԀ
+of.message.shaders.gf2=˙sɔᴉɥdɐɹ⅁ snoꞁnqɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.gf1=˙ʎɔuɐℲ ɹo ʇsɐℲ oʇ sɔᴉɥdɐɹ⅁ ʇǝs ǝsɐǝꞁԀ
 
-of.message.shaders.nv2=s% :uoᴉsɹǝʌ ǝuᴉℲᴉʇdO ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
+of.message.shaders.an2=˙ɥdʎꞁᵷɐuⱯ ᗡƐ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ sɹǝpɐɥS
+of.message.shaders.an1=˙ℲℲO oʇ ɥdʎꞁᵷɐuⱯ ᗡƐ <- ɹǝɥʇO ʇǝs ǝsɐǝꞁԀ
+
+of.message.shaders.nv2=%1$s :uoᴉsɹǝʌ ǝuᴉℲᴉʇdO ɹǝʍǝu ɐ sǝɹᴉnbǝɹ ʞɔɐd ɹǝpɐɥs sᴉɥ⟘
 of.message.shaders.nv1=¿ǝnuᴉʇuoɔ oʇ ʇuɐʍ noʎ ǝɹns noʎ ǝɹⱯ
 
-of.message.newVersion=§e%s§f :ǝꞁqɐꞁᴉɐʌɐ sᴉ uoᴉsɹǝʌ §eǝuᴉℲᴉʇdO§f ʍǝu Ɐ
-of.message.java64Bit=˙ǝɔuɐɯɹoɟɹǝd ǝsɐǝɹɔuᴉ oʇ §eɐʌɐſ ʇᴉq-߈9§f ꞁꞁɐʇsuᴉ uɐɔ no⅄
-of.message.openglError=(s%) s% :§eɹoɹɹƎ ꞀפuǝdO§f
+of.message.newVersion=§f%1$s§e :ǝꞁqɐꞁᴉɐʌɐ sᴉ uoᴉsɹǝʌ §fǝuᴉℲᴉʇdO§e ʍǝu Ɐ
+of.message.java64Bit=˙ǝɔuɐɯɹoɟɹǝd ǝsɐǝɹɔuᴉ oʇ §fɐʌɐſ ʇᴉq-߈9§e ꞁꞁɐʇsuᴉ uɐɔ no⅄
+of.message.openglError=(%2$s) %1$s :§fɹoɹɹƎ Ꞁ⅁uǝdO§e
 
-of.message.shaders.loading=s% :sɹǝpɐɥs ᵷuᴉpɐoꞀ
+of.message.shaders.loading=%1$s :sɹǝpɐɥs ᵷuᴉpɐoꞀ
 
 of.message.other.reset=¿sǝnꞁɐʌ ʇꞁnɐɟǝp ɹᴉǝɥʇ oʇ sᵷuᴉʇʇǝs oǝpᴉʌ ꞁꞁɐ ʇǝsǝᴚ
 
@@ -60,22 +63,24 @@ of.options.skinCustomisation.ofCape=˙˙˙ǝdɐƆ ǝuᴉℲᴉʇdO
 of.options.capeOF.title=ǝdɐƆ ǝuᴉℲᴉʇdO
 of.options.capeOF.openEditor=ɹoʇᴉpƎ ǝdɐƆ uǝdO
 of.options.capeOF.reloadCape=ǝdɐƆ pɐoꞁǝᴚ
-of.options.capeOF.copyEditorLink=pɹɐoqdᴉꞁƆ oʇ ʞuᴉꞀ ʎdoƆ
+of.options.capeOF.copyEditorLink=pɹɐoqdᴉꞁƆ o⟘ ʞuᴉꞀ ʎdoƆ
 
 of.message.capeOF.openEditor=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ uǝdo pꞁnoɥs ɹoʇᴉpǝ ǝdɐɔ ǝuᴉℲᴉʇdO ǝɥ⟘
-of.message.capeOF.openEditorError=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ ʞuᴉꞀ ɹoʇᴉpǝ ǝɥʇ ᵷuᴉuǝdo ɹoɹɹƎ
+of.message.capeOF.openEditorError=˙ɹǝsʍoɹq qǝʍ ɐ uᴉ ʞuᴉꞁ ɹoʇᴉpǝ ǝɥʇ ᵷuᴉuǝdo ɹoɹɹƎ
 of.message.capeOF.reloadCape=˙spuoɔǝs ϛ⥝ uᴉ pǝpɐoꞁǝɹ ǝq ꞁꞁᴉʍ ǝdɐɔ ǝɥ⟘
 
-of.message.capeOF.error2=pǝꞁᴉɐɟ uoᴉʇɐɔᴉʇuǝɥʇnɐ ᵷuɐɾoW.
-of.message.capeOF.error1=%s: ɹoɹɹƎ
+of.message.capeOF.error2=˙pǝꞁᴉɐɟ uoᴉʇɐɔᴉʇuǝɥʇnɐ ᵷuɐɾoW
+of.message.capeOF.error1=%1$s :ɹoɹɹƎ
 
 # Video settings
 
-options.graphics.tooltip.5=ʎʇᴉꞁɐnb ꞁɐnsᴉΛ
-options.graphics.tooltip.4=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ -  ʇsɐℲ  
-options.graphics.tooltip.3=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥᵷᴉɥ - ʎɔuɐℲ  
-options.graphics.tooltip.2='ɹǝʇɐʍ 'sǝʌɐǝꞁ 'spnoꞁɔ ɟo ǝɔuɐɹɐǝddɐ ǝɥʇ sǝᵷuɐɥƆ
-options.graphics.tooltip.1=˙sǝpᴉs ssɐɹᵷ puɐ sʍopɐɥs
+options.graphics.tooltip.7=ʎʇᴉꞁɐnb ꞁɐnsᴉΛ
+options.graphics.tooltip.6=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ - ʇsɐℲ  
+options.graphics.tooltip.5=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥᵷᴉɥ - ʎɔuɐℲ  
+options.graphics.tooltip.4=ʇsǝʍoꞁs 'sʇɔǝɾqo ʇuǝɔnꞁsuɐɹʇ ɹǝʇʇǝq - snoꞁnqɐℲ  
+options.graphics.tooltip.3='ɹǝʇɐʍ 'sǝʌɐǝꞁ 'spnoꞁɔ ɟo ǝɔuɐɹɐǝddɐ ǝɥʇ sǝᵷuɐɥƆ
+options.graphics.tooltip.2=˙sǝpᴉs ssɐɹᵷ puɐ sʍopɐɥs
+options.graphics.tooltip.1=˙sɹǝpɐɥs ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou sᴉ sɔᴉɥdɐɹᵷ snoꞁnqɐℲ
 
 of.options.renderDistance.tiny=ʎuᴉ⟘
 of.options.renderDistance.short=ʇɹoɥS
@@ -90,9 +95,15 @@ options.renderDistance.tooltip.7=(ʇsǝʇsɐɟ) ɯᘔƐ - ʎuᴉ⟘ ᘔ
 options.renderDistance.tooltip.6=(ꞁɐɯɹou) ɯ8ᘔ⥝ - ꞁɐɯɹoN 8  
 options.renderDistance.tooltip.5=(ɹǝʍoꞁs) ɯ9ϛᘔ - ɹɐℲ 9⥝  
 options.renderDistance.tooltip.4=ᵷuᴉpuɐɯǝp ǝɔɹnosǝɹ ʎɹǝʌ (¡ʇsǝʍoꞁs) ɯᘔ⥝ϛ - ǝɯǝɹʇxƎ ᘔƐ  
-options.renderDistance.tooltip.3=pǝʇɐɔoꞁꞁɐ WⱯɹ qפᘔ spǝǝu 'ɯ89ㄥ - ǝuɐsuI 8߈  
-options.renderDistance.tooltip.2=pǝʇɐɔoꞁꞁɐ WⱯɹ qפƐ spǝǝu 'ɯ߈ᘔ0⥝ - snoɹɔᴉpnꞀ ߈9  
+options.renderDistance.tooltip.3=pǝʇɐɔoꞁꞁɐ WⱯᴚ ᗺ⅁ᘔ spǝǝu 'ɯ89ㄥ - ǝuɐsuI 8߈  
+options.renderDistance.tooltip.2=pǝʇɐɔoꞁꞁɐ WⱯᴚ ᗺ⅁Ɛ spǝǝu 'ɯ߈ᘔ0⥝ - snoɹɔᴉpnꞀ ߈9  
 options.renderDistance.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo ǝɹɐ ɹɐℲ 9⥝ ɹǝʌo sǝnꞁɐΛ
+
+options.entityDistanceScaling.tooltip.5=ǝɔuɐʇsᴉp ɹǝpuǝɹ ʎʇᴉʇuƎ
+options.entityDistanceScaling.tooltip.4=ɹǝʇsɐɟ - %%0ϛ  
+options.entityDistanceScaling.tooltip.3=ʇꞁnɐɟǝp - %%00⥝  
+options.entityDistanceScaling.tooltip.2=ɹǝʍoꞁs - %%00ϛ  
+options.entityDistanceScaling.tooltip.1=˙uʍoɥs ǝɹɐ sǝᴉʇᴉʇuǝ ɥɔᴉɥʍ ʇɐ ǝɔuɐʇsᴉp ɯnɯᴉxɐɯ ǝɥʇ sǝᴉɟᴉpoW
 
 options.ao.tooltip.4=ᵷuᴉʇɥᵷᴉꞁ ɥʇooɯS
 options.ao.tooltip.3=(ɹǝʇsɐɟ) ᵷuᴉʇɥᵷᴉꞁ ɥʇooɯs ou - ℲℲO  
@@ -116,39 +127,39 @@ of.options.AO_LEVEL.tooltip.1=sʍopɐɥs ʞɹɐp - %%00⥝
 options.viewBobbing.tooltip.2=˙ʇuǝɯǝʌoɯ ɔᴉʇsᴉꞁɐǝɹ ǝɹoW
 options.viewBobbing.tooltip.1=˙sʇꞁnsǝɹ ʇsǝq ɹoɟ ℲℲO oʇ ʇᴉ ʇǝs sdɐɯdᴉɯ ᵷuᴉsn uǝɥM
 
-options.guiScale.tooltip.6=ǝꞁɐɔS I∩פ
+options.guiScale.tooltip.6=ǝꞁɐɔS I∩⅁
 options.guiScale.tooltip.5=ǝzᴉs ꞁɐɯᴉxɐɯ - oʇnⱯ  
 options.guiScale.tooltip.4=xƐ oʇ x⥝ - ǝᵷɹɐꞀ 'ꞁɐɯɹoN 'ꞁꞁɐɯS  
-options.guiScale.tooltip.3=sʎɐꞁdsᴉp ʞ߈ uo ǝꞁqɐꞁᴉɐʌɐ - x0⥝ oʇ x߈  
+options.guiScale.tooltip.3=sʎɐꞁdsᴉp Ʞ߈ uo ǝꞁqɐꞁᴉɐʌɐ - x0⥝ oʇ x߈  
 options.guiScale.tooltip.2=˙ǝpoɔᴉu∩ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇou ǝɹɐ (˙˙˙ xϛ 'xƐ 'x⥝) sǝnꞁɐʌ ppO
-options.guiScale.tooltip.1=˙ɹǝʇsɐɟ ǝq ʎɐɯ I∩פ ɹǝꞁꞁɐɯs Ɐ
+options.guiScale.tooltip.1=˙ɹǝʇsɐɟ ǝq ʎɐɯ I∩⅁ ɹǝꞁꞁɐɯs Ɐ
 
-options.vbo.tooltip.3=sʇɔǝɾqo ɹǝɟɟnq xǝʇɹǝΛ
+options.vbo=sOᗺΛ ǝs∩
+options.vbo.tooltip.3=sʇɔǝɾqO ɹǝɟɟnᗺ xǝʇɹǝΛ
 options.vbo.tooltip.2=ʎꞁꞁɐnsn sᴉ ɥɔᴉɥʍ ꞁǝpoɯ ᵷuᴉɹǝpuǝɹ ǝʌᴉʇɐuɹǝʇꞁɐ uɐ sǝs∩
 options.vbo.tooltip.1=˙ᵷuᴉɹǝpuǝɹ ʇꞁnɐɟǝp ǝɥʇ uɐɥʇ (%%0⥝-ϛ) ɹǝʇsɐɟ
-options.vbo=sOᗺΛ ǝs∩
 
 options.gamma.tooltip.6=˙sʇɔǝɾqo ɹǝʞɹɐp ɟo ssǝuʇɥᵷᴉɹq ǝɥʇ sǝᵷuɐɥƆ
 options.gamma.tooltip.5=ssǝuʇɥᵷᴉɹq pɹɐpuɐʇs - ʎpooW  
 options.gamma.tooltip.4=ǝꞁqɐᴉɹɐʌ - %%66-⥝  
-options.gamma.tooltip.3=sʇɔǝɾqo ɹǝʞɹɐp ɹoɟ ssǝuʇɥᵷᴉɹq ɯnɯᴉxɐɯ - ʇɥᵷᴉɹq  
-options.gamma.tooltip.2= ɟo ssǝuʇɥᵷᴉɹq ǝɥʇ ǝᵷuɐɥɔ ʇou sǝop uoᴉʇdo sᴉɥ⟘
+options.gamma.tooltip.3=sʇɔǝɾqo ɹǝʞɹɐp ɹoɟ ssǝuʇɥᵷᴉɹq ɯnɯᴉxɐɯ - ʇɥᵷᴉɹᗺ  
+options.gamma.tooltip.2=ɟo ssǝuʇɥᵷᴉɹq ǝɥʇ ǝᵷuɐɥɔ ʇou sǝop uoᴉʇdo sᴉɥ⟘
 options.gamma.tooltip.1=˙sʇɔǝɾqo ʞɔɐꞁq ʎꞁꞁnɟ
 
-options.anaglyph.tooltip.4=ɥdʎꞁᵷɐuⱯ pƐ
-options.anaglyph.tooltip.3=sɹnoꞁoɔ ʇuǝɹǝɟɟᴉp ᵷuᴉsn ʇɔǝɟɟǝ pƐ ɔᴉdoɔsoǝɹǝʇs ɐ sǝꞁqɐuƎ
+options.anaglyph.tooltip.4=ɥdʎꞁᵷɐuⱯ ᗡƐ
+options.anaglyph.tooltip.3=sɹnoꞁoɔ ʇuǝɹǝɟɟᴉp ᵷuᴉsn ʇɔǝɟɟǝ ᗡƐ ɔᴉdoɔsoǝɹǝʇs ɐ sǝꞁqɐuƎ
 options.anaglyph.tooltip.2=˙ǝʎǝ ɥɔɐǝ ɹoɟ
 options.anaglyph.tooltip.1=˙ᵷuᴉʍǝᴉʌ ɹǝdoɹd ɹoɟ sǝssɐꞁᵷ uɐʎɔ-pǝɹ sǝɹᴉnbǝᴚ
 
-options.attackIndicator.tooltip.6=ɹoʇɐɔᴉpuᴉ ʞɔɐʇʇɐ ǝɥʇ ɟo uoᴉʇᴉsod ǝɥʇ sǝɹnbᴉɟuoƆ
+options.attackIndicator.tooltip.6=ɹoʇɐɔᴉpuᴉ ʞɔɐʇʇɐ ǝɥʇ ɟo uoᴉʇᴉsod ǝɥʇ sǝɹnᵷᴉɟuoƆ
 options.attackIndicator.tooltip.5=ɹᴉɐɥssoɹɔ ǝɥʇ ɹǝpun - ɹᴉɐɥssoɹƆ  
 options.attackIndicator.tooltip.4=ɹɐqʇoɥ ǝɥʇ oʇ ʇxǝu - ɹɐqʇoH  
 options.attackIndicator.tooltip.3=ɹoʇɐɔᴉpuᴉ ʞɔɐʇʇɐ ou - ℲℲO  
 options.attackIndicator.tooltip.2=ǝɥʇ ɟo ɹǝʍod ʞɔɐʇʇɐ ǝɥʇ sʍoɥs ɹoʇɐɔᴉpuᴉ ʞɔɐʇʇɐ ǝɥ⟘
 options.attackIndicator.tooltip.1=ɯǝʇᴉ pǝddᴉnbǝ ʎꞁʇuǝɹɹnɔ
 
-of.options.ALTERNATE_BLOCKS=sʞɔoꞁq ǝʇɐuɹǝʇꞁⱯ
-of.options.ALTERNATE_BLOCKS.tooltip.3=sʞɔoꞁq ǝʇɐuɹǝʇꞁⱯ
+of.options.ALTERNATE_BLOCKS=sʞɔoꞁᗺ ǝʇɐuɹǝʇꞁⱯ
+of.options.ALTERNATE_BLOCKS.tooltip.3=sʞɔoꞁᗺ ǝʇɐuɹǝʇꞁⱯ
 of.options.ALTERNATE_BLOCKS.tooltip.2=˙sʞɔoꞁq ǝɯos ɹoɟ sꞁǝpoɯ ʞɔoꞁq ǝʌᴉʇɐuɹǝʇꞁɐ sǝs∩
 of.options.ALTERNATE_BLOCKS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ pǝʇɔǝꞁǝs ǝɥʇ uo spuǝdǝᗡ
 
@@ -157,7 +168,7 @@ of.options.FOG_FANCY.tooltip.6=ǝdʎʇ ᵷoℲ
 of.options.FOG_FANCY.tooltip.5=ᵷoɟ ɹǝʇsɐɟ - ʇsɐℲ  
 of.options.FOG_FANCY.tooltip.4=ɹǝʇʇǝq sʞooꞁ 'ᵷoɟ ɹǝʍoꞁs - ʎɔuɐℲ  
 of.options.FOG_FANCY.tooltip.3=ʇsǝʇsɐɟ 'ᵷoɟ ou - ℲℲO  
-of.options.FOG_FANCY.tooltip.2= ǝɥʇ ʎq pǝʇɹoddns sᴉ ʇᴉ ɟᴉ ʎꞁuo ǝꞁqɐꞁᴉɐʌɐ sᴉ ᵷoɟ ʎɔuɐɟ ǝɥ⟘
+of.options.FOG_FANCY.tooltip.2=ǝɥʇ ʎq pǝʇɹoddns sᴉ ʇᴉ ɟᴉ ʎꞁuo ǝꞁqɐꞁᴉɐʌɐ sᴉ ᵷoɟ ʎɔuɐɟ ǝɥ⟘
 of.options.FOG_FANCY.tooltip.1=˙pɹɐɔ ɔᴉɥdɐɹᵷ
 
 of.options.FOG_START=ʇɹɐʇS ᵷoℲ
@@ -168,10 +179,10 @@ of.options.FOG_START.tooltip.1=˙ǝɔuɐɯɹoɟɹǝd ǝɥʇ ʇɔǝɟɟɐ ʇou s�
 
 of.options.CHUNK_LOADING=ᵷuᴉpɐoꞀ ʞunɥƆ
 of.options.CHUNK_LOADING.tooltip.8=ᵷuᴉpɐoꞀ ʞunɥƆ
-of.options.CHUNK_LOADING.tooltip.7=sʞunɥɔ ᵷuᴉpɐoꞁ uǝɥʍ SԀℲ ǝꞁqɐʇsun - ʇꞁnɐɟǝp  
+of.options.CHUNK_LOADING.tooltip.7=sʞunɥɔ ᵷuᴉpɐoꞁ uǝɥʍ SԀℲ ǝꞁqɐʇsun - ʇꞁnɐɟǝᗡ  
 of.options.CHUNK_LOADING.tooltip.6=SԀℲ ǝꞁqɐʇs - ɥʇooɯS  
 of.options.CHUNK_LOADING.tooltip.5=ᵷuᴉpɐoꞁ pꞁɹoʍ ɹǝʇsɐɟ xƐ 'SԀℲ ǝꞁqɐʇs - ǝɹoƆ-ᴉʇꞁnW  
-of.options.CHUNK_LOADING.tooltip.4= puɐ ᵷuᴉɹǝʇʇnʇs ǝɥʇ ǝʌoɯǝɹ ǝɹoƆ-ᴉʇꞁnW puɐ ɥʇooɯS
+of.options.CHUNK_LOADING.tooltip.4=puɐ ᵷuᴉɹǝʇʇnʇs ǝɥʇ ǝʌoɯǝɹ ǝɹoƆ-ᴉʇꞁnW puɐ ɥʇooɯS
 of.options.CHUNK_LOADING.tooltip.3=˙ᵷuᴉpɐoꞁ ʞunɥɔ ʎq pǝsnɐɔ sǝzǝǝɹɟ
 of.options.CHUNK_LOADING.tooltip.2=puɐ ᵷuᴉpɐoꞁ pꞁɹoʍ ǝɥʇ xƐ dn pǝǝds uɐɔ ǝɹoƆ-ᴉʇꞁnW
 of.options.CHUNK_LOADING.tooltip.1=˙ǝɹoɔ ∩ԀƆ puoɔǝs ɐ ᵷuᴉsn ʎq SԀℲ ǝsɐǝɹɔuᴉ
@@ -191,14 +202,14 @@ of.options.shaders.ANTIALIASING.tooltip.5=(ɹǝʍoꞁs) sǝᵷpǝ puɐ sǝuᴉ�
 of.options.shaders.ANTIALIASING.tooltip.4=sɥʇooɯs ɥɔᴉɥʍ ʇɔǝɟɟǝ ᵷuᴉssǝɔoɹd-ʇsod ɐ sᴉ ⱯⱯXℲ
 of.options.shaders.ANTIALIASING.tooltip.3=˙suoᴉʇᴉsuɐɹʇ ɹoꞁoɔ dɹɐɥs puɐ sǝuᴉꞁ pǝᵷᵷɐɾ
 of.options.shaders.ANTIALIASING.tooltip.2=ᵷuᴉsɐᴉꞁɐᴉʇuɐ ꞁɐuoᴉʇᴉpɐɹʇ uɐɥʇ ɹǝʇsɐɟ sᴉ ʇI
-of.options.shaders.ANTIALIASING.tooltip.1=  ˙ɹǝpuǝɹ ʇsɐℲ puɐ sɹǝpɐɥs ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ sᴉ puɐ
+of.options.shaders.ANTIALIASING.tooltip.1=˙sɹǝpɐɥs ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ sᴉ puɐ
 
 of.options.shaders.NORMAL_MAP=dɐW ꞁɐɯɹoN
 of.options.shaders.NORMAL_MAP.tooltip.7=dɐW ꞁɐɯɹoN
-of.options.shaders.NORMAL_MAP.tooltip.6= sdɐɯ ꞁɐɯɹou ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - NO  
+of.options.shaders.NORMAL_MAP.tooltip.6=sdɐɯ ꞁɐɯɹou ǝꞁqɐuǝ (ʇꞁnɐɟǝp) - NO  
 of.options.shaders.NORMAL_MAP.tooltip.5=sdɐɯ ꞁɐɯɹou ǝꞁqɐsᴉp - ℲℲO  
 of.options.shaders.NORMAL_MAP.tooltip.4=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝq uɐɔ sdɐɯ ꞁɐɯɹoN
-of.options.shaders.NORMAL_MAP.tooltip.3=˙sǝɔɐɟɹns ꞁǝpoɯ ʇɐꞁɟ uo ʎɹʇǝɯoǝᵷ pƐ ǝʇɐꞁnɯᴉs oʇ
+of.options.shaders.NORMAL_MAP.tooltip.3=˙sǝɔɐɟɹns ꞁǝpoɯ ʇɐꞁɟ uo ʎɹʇǝɯoǝᵷ ᗡƐ ǝʇɐꞁnɯᴉs oʇ
 of.options.shaders.NORMAL_MAP.tooltip.2=ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ dɐɯ ꞁɐɯɹou ǝɥ⟘
 of.options.shaders.NORMAL_MAP.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ
 
@@ -211,28 +222,28 @@ of.options.shaders.SPECULAR_MAP.tooltip.3=˙sʇɔǝɟɟǝ uoᴉʇɔǝꞁɟǝɹ �
 of.options.shaders.SPECULAR_MAP.tooltip.2=ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sǝɹnʇxǝʇ dɐɯ ɹɐꞁnɔǝds ǝɥ⟘
 of.options.shaders.SPECULAR_MAP.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ
 
-of.options.shaders.RENDER_RES_MUL=ʎʇᴉꞁɐnQ ɹǝpuǝᴚ
-of.options.shaders.RENDER_RES_MUL.tooltip.8=ʎʇᴉꞁɐnQ ɹǝpuǝᴚ
+of.options.shaders.RENDER_RES_MUL=ʎʇᴉꞁɐnꝹ ɹǝpuǝᴚ
+of.options.shaders.RENDER_RES_MUL.tooltip.8=ʎʇᴉꞁɐnꝹ ɹǝpuǝᴚ
 of.options.shaders.RENDER_RES_MUL.tooltip.7=(ʇsǝʇsɐɟ) ʍoꞁ - xϛ˙0  
 of.options.shaders.RENDER_RES_MUL.tooltip.6=(ʇꞁnɐɟǝp) pɹɐpuɐʇs - x⥝  
 of.options.shaders.RENDER_RES_MUL.tooltip.5=(ʇsǝʍoꞁs) ɥᵷᴉɥ - xᘔ  
-of.options.shaders.RENDER_RES_MUL.tooltip.4= ǝɹnʇxǝʇ ǝɥʇ ɟo ǝzᴉs ǝɥʇ sꞁoɹʇuoɔ ʎʇᴉꞁɐnb ɹǝpuǝᴚ
+of.options.shaders.RENDER_RES_MUL.tooltip.4=ǝɹnʇxǝʇ ǝɥʇ ɟo ǝzᴉs ǝɥʇ sꞁoɹʇuoɔ ʎʇᴉꞁɐnb ɹǝpuǝᴚ
 of.options.shaders.RENDER_RES_MUL.tooltip.3=˙oʇ ᵷuᴉɹǝpuǝɹ sᴉ ʞɔɐd ɹǝpɐɥs ǝɥʇ ʇɐɥʇ
-of.options.shaders.RENDER_RES_MUL.tooltip.2=˙sʎɐꞁdsᴉp ʞ߈ ɥʇᴉʍ ꞁnɟǝsn ǝq uɐɔ sǝnꞁɐʌ ɹǝʍoꞀ
+of.options.shaders.RENDER_RES_MUL.tooltip.2=˙sʎɐꞁdsᴉp Ʞ߈ ɥʇᴉʍ ꞁnɟǝsn ǝq uɐɔ sǝnꞁɐʌ ɹǝʍoꞀ
 of.options.shaders.RENDER_RES_MUL.tooltip.1=˙ɹǝʇꞁᴉɟ ᵷuᴉsɐᴉꞁɐᴉʇuɐ uɐ sɐ ʞɹoʍ sǝnꞁɐʌ ɹǝɥᵷᴉH
 
-of.options.shaders.SHADOW_RES_MUL=ʎʇᴉꞁɐnQ ʍopɐɥS
-of.options.shaders.SHADOW_RES_MUL.tooltip.8=ʎʇᴉꞁɐnQ ʍopɐɥS
+of.options.shaders.SHADOW_RES_MUL=ʎʇᴉꞁɐnꝹ ʍopɐɥS
+of.options.shaders.SHADOW_RES_MUL.tooltip.8=ʎʇᴉꞁɐnꝹ ʍopɐɥS
 of.options.shaders.SHADOW_RES_MUL.tooltip.7=(ʇsǝʇsɐɟ) ʍoꞁ - xϛ˙0  
 of.options.shaders.SHADOW_RES_MUL.tooltip.6=(ʇꞁnɐɟǝp) pɹɐpuɐʇs - x⥝  
 of.options.shaders.SHADOW_RES_MUL.tooltip.5=(ʇsǝʍoꞁs) ɥᵷᴉɥ - xᘔ  
 of.options.shaders.SHADOW_RES_MUL.tooltip.4=dɐɯ ʍopɐɥs ǝɥʇ ɟo ǝzᴉs ǝɥʇ sꞁoɹʇuoɔ ʎʇᴉꞁɐnb ʍopɐɥS
 of.options.shaders.SHADOW_RES_MUL.tooltip.3=˙ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝsn ǝɹnʇxǝʇ
-of.options.shaders.SHADOW_RES_MUL.tooltip.2= sǝnꞁɐʌ ɹǝʍoꞀ
-of.options.shaders.SHADOW_RES_MUL.tooltip.1= sǝnꞁɐʌ ɹǝɥᵷᴉH
+of.options.shaders.SHADOW_RES_MUL.tooltip.2=˙sʍopɐɥs ɹǝsɹɐoɔ 'ʇɔɐxǝuᴉ = sǝnꞁɐʌ ɹǝʍoꞀ
+of.options.shaders.SHADOW_RES_MUL.tooltip.1=˙sʍopɐɥs ɹǝuᴉɟ 'pǝꞁᴉɐʇǝp = sǝnꞁɐʌ ɹǝɥᵷᴉH
 
-of.options.shaders.HAND_DEPTH_MUL=ɥʇdǝp puɐH
-of.options.shaders.HAND_DEPTH_MUL.tooltip.8=ɥʇdǝp puɐH
+of.options.shaders.HAND_DEPTH_MUL=ɥʇdǝᗡ puɐH
+of.options.shaders.HAND_DEPTH_MUL.tooltip.8=ɥʇdǝᗡ puɐH
 of.options.shaders.HAND_DEPTH_MUL.tooltip.7=ɐɹǝɯɐɔ ǝɥʇ oʇ ɹɐǝu puɐɥ - xϛ˙0  
 of.options.shaders.HAND_DEPTH_MUL.tooltip.6=(ʇꞁnɐɟǝp) - x⥝  
 of.options.shaders.HAND_DEPTH_MUL.tooltip.5=ɐɹǝɯɐɔ ǝɥʇ ɯoɹɟ ɹɐɟ puɐɥ - xᘔ  
@@ -245,26 +256,26 @@ of.options.shaders.CLOUD_SHADOW=ʍopɐɥS pnoꞁƆ
 
 of.options.shaders.OLD_HAND_LIGHT=ʇɥᵷᴉꞀ puɐH pꞁO
 of.options.shaders.OLD_HAND_LIGHT.tooltip.7=ʇɥᵷᴉꞀ puɐH pꞁO
-of.options.shaders.OLD_HAND_LIGHT.tooltip.6=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝp  
+of.options.shaders.OLD_HAND_LIGHT.tooltip.6=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝᗡ  
 of.options.shaders.OLD_HAND_LIGHT.tooltip.5=ʇɥᵷᴉꞁpuɐɥ pꞁo ǝsn - NO  
 of.options.shaders.OLD_HAND_LIGHT.tooltip.4=ʇɥᵷᴉꞁpuɐɥ ʍǝu ǝsn - ℲℲO  
-of.options.shaders.OLD_HAND_LIGHT.tooltip.3=  ʎꞁuo ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥs sʍoꞁꞁɐ ʇɥᵷᴉꞁ puɐɥ pꞁO
-of.options.shaders.OLD_HAND_LIGHT.tooltip.2= puɐɥ uᴉɐɯ ǝɥʇ uᴉ sɯǝʇᴉ ᵷuᴉʇʇᴉɯǝ ʇɥᵷᴉꞁ ǝsᴉuᵷoɔǝɹ
+of.options.shaders.OLD_HAND_LIGHT.tooltip.3=ʎꞁuo ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥs sʍoꞁꞁɐ ʇɥᵷᴉꞁ puɐɥ pꞁO
+of.options.shaders.OLD_HAND_LIGHT.tooltip.2=puɐɥ uᴉɐɯ ǝɥʇ uᴉ sɯǝʇᴉ ᵷuᴉʇʇᴉɯǝ ʇɥᵷᴉꞁ ǝsᴉuᵷoɔǝɹ
 of.options.shaders.OLD_HAND_LIGHT.tooltip.1=˙puɐɥ-ɟɟo ǝɥʇ uᴉ sɯǝʇᴉ ɥʇᴉʍ ʞɹoʍ osꞁɐ oʇ
 
 of.options.shaders.OLD_LIGHTING=ᵷuᴉʇɥᵷᴉꞀ pꞁO
 of.options.shaders.OLD_LIGHTING.tooltip.8=ᵷuᴉʇɥᵷᴉꞀ pꞁO
-of.options.shaders.OLD_LIGHTING.tooltip.7=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝp  
+of.options.shaders.OLD_LIGHTING.tooltip.7=ʞɔɐd ɹǝpɐɥs ǝɥʇ ʎq pǝꞁꞁoɹʇuoɔ - ʇꞁnɐɟǝᗡ  
 of.options.shaders.OLD_LIGHTING.tooltip.6=ᵷuᴉʇɥᵷᴉꞁ pꞁo ǝsn - NO  
 of.options.shaders.OLD_LIGHTING.tooltip.5=ᵷuᴉʇɥᵷᴉꞁ pꞁo ǝsn ʇou op - ℲℲO  
-of.options.shaders.OLD_LIGHTING.tooltip.4= pǝᴉꞁddɐ ᵷuᴉʇɥᵷᴉꞁ pǝxᴉɟ ǝɥʇ sꞁoɹʇuoɔ ᵷuᴉʇɥᵷᴉꞁ pꞁO
-of.options.shaders.OLD_LIGHTING.tooltip.3= ˙sǝpᴉs ʞɔoꞁq ǝɥʇ oʇ ɐꞁꞁᴉuɐʌ ʎq
-of.options.shaders.OLD_LIGHTING.tooltip.2= ǝpᴉʌoɹd ʎꞁꞁɐnsn sʍopɐɥs ǝsn ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥS
+of.options.shaders.OLD_LIGHTING.tooltip.4=pǝᴉꞁddɐ ᵷuᴉʇɥᵷᴉꞁ pǝxᴉɟ ǝɥʇ sꞁoɹʇuoɔ ᵷuᴉʇɥᵷᴉꞁ pꞁO
+of.options.shaders.OLD_LIGHTING.tooltip.3=˙sǝpᴉs ʞɔoꞁq ǝɥʇ oʇ ɐꞁꞁᴉuɐʌ ʎq
+of.options.shaders.OLD_LIGHTING.tooltip.2=ǝpᴉʌoɹd ʎꞁꞁɐnsn sʍopɐɥs ǝsn ɥɔᴉɥʍ sʞɔɐd ɹǝpɐɥS
 of.options.shaders.OLD_LIGHTING.tooltip.1=˙uoᴉʇᴉsod uns ǝɥʇ uo ᵷuᴉpuǝdǝp ᵷuᴉʇɥᵷᴉꞁ ɹǝʇʇǝq ɥɔnɯ
 
 of.options.shaders.DOWNLOAD=sɹǝpɐɥS pɐoꞁuʍoᗡ
 of.options.shaders.DOWNLOAD.tooltip.5=sɹǝpɐɥS pɐoꞁuʍoᗡ
-of.options.shaders.DOWNLOAD.tooltip.4= 
+of.options.shaders.DOWNLOAD.tooltip.4=
 of.options.shaders.DOWNLOAD.tooltip.3=˙ɹǝsʍoɹq ɐ uᴉ ǝᵷɐd sʞɔɐd ɹǝpɐɥs ǝɥʇ suǝdO
 of.options.shaders.DOWNLOAD.tooltip.2=,,ɹǝpꞁoℲ sɹǝpɐɥS,, ǝɥʇ uᴉ sʞɔɐd ɹǝpɐɥs pǝpɐoꞁuʍop ǝɥʇ ʇnԀ
 of.options.shaders.DOWNLOAD.tooltip.1=˙sɹǝpɐɥs pǝꞁꞁɐʇsuᴉ ɟo ʇsᴉꞁ ǝɥʇ uᴉ ɹɐǝddɐ ꞁꞁᴉʍ ʎǝɥʇ puɐ
@@ -272,12 +283,12 @@ of.options.shaders.DOWNLOAD.tooltip.1=˙sɹǝpɐɥs pǝꞁꞁɐʇsuᴉ ɟo ʇs�
 of.options.shaders.SHADER_PACK=ʞɔɐԀ ɹǝpɐɥS
 
 of.options.shaders.shadersFolder=ɹǝpꞁoℲ sɹǝpɐɥS
-of.options.shaders.shaderOptions=˙˙˙suoᴉʇdo ɹǝpɐɥS
+of.options.shaders.shaderOptions=˙˙˙suoᴉʇdO ɹǝpɐɥS
 
-of.options.shaderOptionsTitle=suoᴉʇdo ɹǝpɐɥS
+of.options.shaderOptionsTitle=suoᴉʇdO ɹǝpɐɥS
 
-of.options.quality=˙˙˙ʎʇᴉꞁɐnQ
-of.options.qualityTitle=sᵷuᴉʇʇǝS ʎʇᴉꞁɐnQ
+of.options.quality=˙˙˙ʎʇᴉꞁɐnꝹ
+of.options.qualityTitle=sᵷuᴉʇʇǝS ʎʇᴉꞁɐnꝹ
 
 of.options.details=˙˙˙sꞁᴉɐʇǝᗡ
 of.options.detailsTitle=sᵷuᴉʇʇǝS ꞁᴉɐʇǝᗡ
@@ -314,7 +325,7 @@ of.options.MIPMAP_TYPE.tooltip.6=ɹǝʇʇǝq ʞooꞁ sʇɔǝɾqo ʇuɐʇsᴉp s�
 of.options.MIPMAP_TYPE.tooltip.5=sꞁᴉɐʇǝp ǝɹnʇxǝʇ ǝɥʇ ᵷuᴉɥʇooɯs ʎq
 of.options.MIPMAP_TYPE.tooltip.4=(ʇsǝʇsɐɟ) ᵷuᴉɥʇooɯs ɥᵷnoɹ - ʇsǝɹɐǝN  
 of.options.MIPMAP_TYPE.tooltip.3=ᵷuᴉɥʇooɯs ꞁɐɯɹou - ɹɐǝuᴉꞀ  
-of.options.MIPMAP_TYPE.tooltip.2=ᵷuᴉɥʇooɯs ǝuᴉɟ - ɹɐǝuᴉꞁᴉq  
+of.options.MIPMAP_TYPE.tooltip.2=ᵷuᴉɥʇooɯs ǝuᴉɟ - ɹɐǝuᴉꞁᴉᗺ  
 of.options.MIPMAP_TYPE.tooltip.1=(ʇsǝʍoꞁs) ᵷuᴉɥʇooɯs ʇsǝuᴉɟ - ɹɐǝuᴉꞁᴉɹ⟘  
 
 
@@ -322,11 +333,11 @@ of.options.AA_LEVEL=ᵷuᴉsɐᴉꞁɐᴉʇuⱯ
 of.options.AA_LEVEL.tooltip.8=ᵷuᴉsɐᴉꞁɐᴉʇuⱯ
 of.options.AA_LEVEL.tooltip.7=(ɹǝʇsɐɟ) ᵷuᴉsɐᴉꞁɐᴉʇuɐ ou (ʇꞁnɐɟǝp) - ℲℲO 
 of.options.AA_LEVEL.tooltip.6=(ɹǝʍoꞁs) sǝᵷpǝ puɐ sǝuᴉꞁ pǝsɐᴉꞁɐᴉʇuɐ - 9⥝-ᘔ 
-of.options.AA_LEVEL.tooltip.5= puɐ sǝuᴉꞁ pǝᵷᵷɐɾ sɥʇooɯs ᵷuᴉsɐᴉꞁɐᴉʇuⱯ ǝɥ⟘
+of.options.AA_LEVEL.tooltip.5=puɐ sǝuᴉꞁ pǝᵷᵷɐɾ sɥʇooɯs ᵷuᴉsɐᴉꞁɐᴉʇuⱯ ǝɥ⟘
 of.options.AA_LEVEL.tooltip.4=˙suoᴉʇᴉsuɐɹʇ ɹnoꞁoɔ dɹɐɥs
 of.options.AA_LEVEL.tooltip.3=˙SԀℲ ǝɥʇ ǝsɐǝɹɔǝp ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ ʇᴉ pǝꞁqɐuǝ uǝɥM
 of.options.AA_LEVEL.tooltip.2=˙spɹɐɔ sɔᴉɥdɐɹᵷ ꞁꞁɐ ʎq pǝʇɹoddns ǝɹɐ sꞁǝʌǝꞁ ꞁꞁɐ ʇoN
-of.options.AA_LEVEL.tooltip.1=¡⟘ɹⱯ⟘SƎɹ ɐ ɹǝʇɟɐ ǝʌᴉʇɔǝɟɟƎ
+of.options.AA_LEVEL.tooltip.1=¡⟘ᴚⱯ⟘SƎᴚ ɐ ɹǝʇɟɐ ǝʌᴉʇɔǝɟɟƎ
 
 of.options.AF_LEVEL=ᵷuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉuⱯ
 of.options.AF_LEVEL.tooltip.6=ᵷuᴉɹǝʇꞁᴉℲ ɔᴉdoɹʇosᴉuⱯ
@@ -348,8 +359,8 @@ of.options.RANDOM_ENTITIES.tooltip.3=ɹǝʍoꞁs 'sǝᴉʇᴉʇuǝ ɯopuɐɹ - N
 of.options.RANDOM_ENTITIES.tooltip.2=˙sǝᴉʇᴉʇuǝ ǝɯɐᵷ ǝɥʇ ɹoɟ sǝɹnʇxǝʇ ɯopuɐɹ sǝsn sǝᴉʇᴉʇuǝ ɯopuɐᴚ
 of.options.RANDOM_ENTITIES.tooltip.1=˙sǝɹnʇxǝʇ ʎʇᴉʇuǝ ǝꞁdᴉʇꞁnɯ sɐɥ ɥɔᴉɥʍ ʞɔɐd ǝɔɹnosǝɹ ɐ spǝǝu ʇI
 
-of.options.BETTER_GRASS=ssɐɹפ ɹǝʇʇǝᗺ
-of.options.BETTER_GRASS.tooltip.4=ssɐɹפ ɹǝʇʇǝᗺ
+of.options.BETTER_GRASS=ssɐɹ⅁ ɹǝʇʇǝᗺ
+of.options.BETTER_GRASS.tooltip.4=ssɐɹ⅁ ɹǝʇʇǝᗺ
 of.options.BETTER_GRASS.tooltip.3=ʇsǝʇsɐɟ 'ǝɹnʇxǝʇ ssɐɹᵷ ǝpᴉs ʇꞁnɐɟǝp - ℲℲO  
 of.options.BETTER_GRASS.tooltip.2=ɹǝʍoꞁs 'ǝɹnʇxǝʇ ssɐɹᵷ ǝpᴉs ꞁꞁnɟ - ʇsɐℲ  
 of.options.BETTER_GRASS.tooltip.1=ʇsǝʍoꞁs 'ǝɹnʇxǝʇ ssɐɹᵷ ǝpᴉs ɔᴉɯɐuʎp - ʎɔuɐℲ  
@@ -370,19 +381,19 @@ of.options.CUSTOM_FONTS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.CUSTOM_COLORS=sɹnoꞁoƆ ɯoʇsnƆ
 of.options.CUSTOM_COLORS.tooltip.5=sɹnoꞁoƆ ɯoʇsnƆ
-of.options.CUSTOM_COLORS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ ɯoʇsnɔ sǝsn - NO  
-of.options.CUSTOM_COLORS.tooltip.3=ɹǝʇsɐɟ ' sɹnoꞁoɔ ʇꞁnɐɟǝp sǝsn - ℲℲO  
-of.options.CUSTOM_COLORS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ  sɹnoꞁoɔ ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_COLORS.tooltip.4=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sɹnoꞁoɔ ɯoʇsnɔ sǝsn - NO  
+of.options.CUSTOM_COLORS.tooltip.3=ɹǝʇsɐɟ 'sɹnoꞁoɔ ʇꞁnɐɟǝp sǝsn - ℲℲO  
+of.options.CUSTOM_COLORS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sɹnoꞁoɔ ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_COLORS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
 of.options.SWAMP_COLORS=sɹnoꞁoƆ dɯɐʍS
 of.options.SWAMP_COLORS.tooltip.4=sɹnoꞁoƆ dɯɐʍS
-of.options.SWAMP_COLORS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp)  sɹnoꞁoɔ dɯɐʍs ǝsn - NO  
+of.options.SWAMP_COLORS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sɹnoꞁoɔ dɯɐʍs ǝsn - NO  
 of.options.SWAMP_COLORS.tooltip.2=ɹǝʇsɐɟ 'sɹnoꞁoɔ dɯɐʍs ǝsn ʇou op - ℲℲO  
 of.options.SWAMP_COLORS.tooltip.1=˙ɹǝʇɐʍ puɐ sǝuᴉʌ 'sǝʌɐǝꞁ 'ssɐɹᵷ ʇɔǝɟɟɐ sɹnoꞁoɔ dɯɐʍs ǝɥ⟘
 
-of.options.SMOOTH_BIOMES=sǝɯoᴉq ɥʇooɯS
-of.options.SMOOTH_BIOMES.tooltip.6=sǝɯoᴉq ɥʇooɯS
+of.options.SMOOTH_BIOMES=sǝɯoᴉᗺ ɥʇooɯS
+of.options.SMOOTH_BIOMES.tooltip.6=sǝɯoᴉᗺ ɥʇooɯS
 of.options.SMOOTH_BIOMES.tooltip.5=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sɹǝpɹoq ǝɯoᴉq ɟo ᵷuᴉɥʇooɯs - NO  
 of.options.SMOOTH_BIOMES.tooltip.4=ɹǝʇsɐɟ 'sɹǝpɹoq ǝɯoᴉq ɟo ᵷuᴉɥʇooɯs ou - ℲℲO  
 of.options.SMOOTH_BIOMES.tooltip.3=puɐ ᵷuᴉꞁdɯɐs ʎq ǝuop sᴉ sɹǝpɹoq ǝɯoᴉq ɟo ᵷuᴉɥʇooɯs ǝɥ⟘
@@ -440,22 +451,22 @@ of.options.CUSTOM_ENTITY_MODELS.tooltip.3=ɹǝʇsɐɟ 'sꞁǝpoɯ ʎʇᴉʇuǝ �
 of.options.CUSTOM_ENTITY_MODELS.tooltip.2=ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sꞁǝpoɯ ʎʇᴉʇuǝ ɯoʇsnɔ ǝɥ⟘
 of.options.CUSTOM_ENTITY_MODELS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ
 
-of.options.CUSTOM_GUIS=sI∩פ ɯoʇsnƆ
-of.options.CUSTOM_GUIS.tooltip.4=sI∩פ ɯoʇsnƆ
-of.options.CUSTOM_GUIS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sI∩פ ɯoʇsnɔ - NO  
-of.options.CUSTOM_GUIS.tooltip.2=ɹǝʇsɐɟ 'sI∩פ ʇꞁnɐɟǝp - ℲℲO  
-of.options.CUSTOM_GUIS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sI∩פ ɯoʇsnɔ ǝɥ⟘
+of.options.CUSTOM_GUIS=sI∩⅁ ɯoʇsnƆ
+of.options.CUSTOM_GUIS.tooltip.4=sI∩⅁ ɯoʇsnƆ
+of.options.CUSTOM_GUIS.tooltip.3=ɹǝʍoꞁs '(ʇꞁnɐɟǝp) sI∩⅁ ɯoʇsnɔ - NO  
+of.options.CUSTOM_GUIS.tooltip.2=ɹǝʇsɐɟ 'sI∩⅁ ʇꞁnɐɟǝp - ℲℲO  
+of.options.CUSTOM_GUIS.tooltip.1=˙ʞɔɐd ǝɔɹnosǝɹ ʇuǝɹɹnɔ ǝɥʇ ʎq pǝᴉꞁddns ǝɹɐ sI∩⅁ ɯoʇsnɔ ǝɥ⟘
 
 # Details
 
 of.options.CLOUDS=spnoꞁƆ
 of.options.CLOUDS.tooltip.7=spnoꞁƆ
-of.options.CLOUDS.tooltip.6=sɔᴉɥdɐɹפ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.CLOUDS.tooltip.6=sɔᴉɥdɐɹ⅁ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝᗡ  
 of.options.CLOUDS.tooltip.5=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ - ʇsɐℲ  
 of.options.CLOUDS.tooltip.4=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ɹǝɥᵷᴉɥ - ʎɔuɐℲ  
 of.options.CLOUDS.tooltip.3=ʇsǝʇsɐɟ 'spnoꞁɔ ou - ℲℲO  
-of.options.CLOUDS.tooltip.2=˙pᘔ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʇsɐℲ
-of.options.CLOUDS.tooltip.1=˙pƐ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʎɔuɐℲ
+of.options.CLOUDS.tooltip.2=˙ᗡᘔ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʇsɐℲ
+of.options.CLOUDS.tooltip.1=˙ᗡƐ pǝɹǝpuǝɹ ǝɹɐ spnoꞁɔ ʎɔuɐℲ
 
 of.options.CLOUD_HEIGHT=ʇɥᵷᴉǝH pnoꞁƆ
 of.options.CLOUD_HEIGHT.tooltip.3=ʇɥᵷᴉǝH pnoꞁƆ
@@ -464,7 +475,7 @@ of.options.CLOUD_HEIGHT.tooltip.1=ʇᴉɯᴉꞁ ʇɥᵷᴉǝɥ pꞁɹoʍ ǝʌoq�
 
 of.options.TREES=sǝǝɹ⟘
 of.options.TREES.tooltip.7=sǝǝɹ⟘
-of.options.TREES.tooltip.6=sɔᴉɥdɐɹפ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.TREES.tooltip.6=sɔᴉɥdɐɹ⅁ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝᗡ  
 of.options.TREES.tooltip.5=ɹǝʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝʍoꞁ - ʇsɐℲ  
 of.options.TREES.tooltip.4=ʇsɐɟ 'ʎʇᴉꞁɐnb ɹǝɥᵷᴉɥ - ʇɹɐɯS  
 of.options.TREES.tooltip.3=ɹǝʍoꞁs 'ʎʇᴉꞁɐnb ʇsǝɥᵷᴉɥ - ʎɔuɐℲ  
@@ -473,7 +484,7 @@ of.options.TREES.tooltip.1=˙sǝʌɐǝꞁ ʇuǝɹɐdsuɐɹʇ ǝʌɐɥ sǝǝɹʇ 
 
 of.options.RAIN=ʍouS ⅋ uᴉɐᴚ
 of.options.RAIN.tooltip.7=ʍouS ⅋ uᴉɐᴚ
-of.options.RAIN.tooltip.6=sɔᴉɥdɐɹפ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.RAIN.tooltip.6=sɔᴉɥdɐɹ⅁ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝᗡ  
 of.options.RAIN.tooltip.5=ɹǝʇsɐɟ 'ʍous/uᴉɐɹ ʇɥᵷᴉꞁ -  ʇsɐℲ  
 of.options.RAIN.tooltip.4=ɹǝʍoꞁs 'ʍous/uᴉɐɹ ʎʌɐǝɥ - ʎɔuɐℲ  
 of.options.RAIN.tooltip.3=ʇsǝʇsɐɟ 'ʍous/uᴉɐɹ ou - ℲℲO  
@@ -501,13 +512,13 @@ of.options.SHOW_CAPES.tooltip.3=sǝdɐƆ ʍoɥS
 of.options.SHOW_CAPES.tooltip.2=(ʇꞁnɐɟǝp) sǝdɐɔ ɹǝʎɐꞁd ʍoɥs - NO  
 of.options.SHOW_CAPES.tooltip.1=sǝdɐɔ ɹǝʎɐꞁd ʍoɥs ʇou op - ℲℲO  
 
-of.options.TRANSLUCENT_BLOCKS=sʞɔoꞁq ʇuǝɔnꞁsuɐɹ⟘
-of.options.TRANSLUCENT_BLOCKS.tooltip.7=sʞɔoꞁq ʇuǝɔnꞁsuɐɹ⟘
-of.options.TRANSLUCENT_BLOCKS.tooltip.6=sɔᴉɥdɐɹפ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
-of.options.TRANSLUCENT_BLOCKS.tooltip.5=(ɹǝʍoꞁs) ᵷuᴉpuǝꞁq ɹnoꞁoɔ ʇɔǝɹɹoɔ - ʎɔuɐℲ  
+of.options.TRANSLUCENT_BLOCKS=sʞɔoꞁᗺ ʇuǝɔnꞁsuɐɹ⟘
+of.options.TRANSLUCENT_BLOCKS.tooltip.7=sʞɔoꞁᗺ ʇuǝɔnꞁsuɐɹ⟘
+of.options.TRANSLUCENT_BLOCKS.tooltip.6=sɔᴉɥdɐɹ⅁ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝᗡ  
+of.options.TRANSLUCENT_BLOCKS.tooltip.5=(ʇꞁnɐɟǝp) ᵷuᴉpuǝꞁq ɹnoꞁoɔ ʇɔǝɹɹoɔ - ʎɔuɐℲ  
 of.options.TRANSLUCENT_BLOCKS.tooltip.4=(ɹǝʇsɐɟ) ᵷuᴉpuǝꞁq ɹnoꞁoɔ ʇsɐɟ - ʇsɐℲ  
 of.options.TRANSLUCENT_BLOCKS.tooltip.3=sʞɔoꞁq ʇuǝɔnꞁsuɐɹʇ ɟo ᵷuᴉpuǝꞁq ɹnoꞁoɔ ǝɥʇ sꞁoɹʇuoƆ
-of.options.TRANSLUCENT_BLOCKS.tooltip.2=(ǝɔᴉ 'ɹǝʇɐʍ 'ssɐꞁᵷ pǝuᴉɐʇs) sɹnoꞁoɔ ʇuǝɹǝɟɟᴉp ɥʇᴉʍ
+of.options.TRANSLUCENT_BLOCKS.tooltip.2=(ǝɔᴉ 'ɹǝʇɐʍ 'ssɐꞁᵷ pǝuᴉɐʇs) ɹnoꞁoɔ ʇuǝɹǝɟɟᴉp ɥʇᴉʍ
 of.options.TRANSLUCENT_BLOCKS.tooltip.1=˙ɯǝɥʇ uǝǝʍʇǝq ɹᴉɐ ɥʇᴉʍ ɹǝɥʇo ɥɔɐǝ puᴉɥǝq pǝɔɐꞁd uǝɥʍ
 
 of.options.HELD_ITEM_TOOLTIPS=sdᴉʇꞁoo⟘ ɯǝʇI pꞁǝH
@@ -517,7 +528,7 @@ of.options.HELD_ITEM_TOOLTIPS.tooltip.1=sɯǝʇᴉ pꞁǝɥ ɹoɟ sdᴉʇꞁooʇ
 
 of.options.ADVANCED_TOOLTIPS=sdᴉʇꞁoo⟘ pǝɔuɐʌpⱯ
 of.options.ADVANCED_TOOLTIPS.tooltip.6=sdᴉʇꞁooʇ pǝɔuɐʌpⱯ
-of.options.ADVANCED_TOOLTIPS.tooltip.5= sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs - NO  
+of.options.ADVANCED_TOOLTIPS.tooltip.5=sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs - NO  
 of.options.ADVANCED_TOOLTIPS.tooltip.4=(ʇꞁnɐɟǝp) sdᴉʇꞁooʇ pǝɔuɐʌpɐ ʍoɥs ʇou op - ℲℲO  
 of.options.ADVANCED_TOOLTIPS.tooltip.3=ɹoɟ uoᴉʇɐɯɹoɟuᴉ pǝpuǝʇxǝ ʍoɥs sdᴉʇꞁooʇ pǝɔuɐʌpⱯ
 of.options.ADVANCED_TOOLTIPS.tooltip.2=suoᴉʇdo ɹǝpɐɥs ɹoɟ puɐ (ʎʇᴉꞁᴉqɐɹnp 'pᴉ) sɯǝʇᴉ
@@ -525,9 +536,9 @@ of.options.ADVANCED_TOOLTIPS.tooltip.1=˙(ǝnꞁɐʌ ʇꞁnɐɟǝp 'ǝɔɹnos 'p
 
 of.options.DROPPED_ITEMS=sɯǝʇI pǝddoɹᗡ
 of.options.DROPPED_ITEMS.tooltip.4=sɯǝʇI pǝddoɹᗡ
-of.options.DROPPED_ITEMS.tooltip.3=sɔᴉɥdɐɹפ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
-of.options.DROPPED_ITEMS.tooltip.2=(ɹǝʇsɐɟ) sɯǝʇᴉ pǝddoɹp pᘔ - ʇsɐℲ  
-of.options.DROPPED_ITEMS.tooltip.1=(ɹǝʍoꞁs) sɯǝʇᴉ pǝddoɹp pƐ - ʎɔuɐℲ  
+of.options.DROPPED_ITEMS.tooltip.3=sɔᴉɥdɐɹ⅁ ᵷuᴉʇʇǝs ʎq ʇǝs sɐ - ʇꞁnɐɟǝᗡ  
+of.options.DROPPED_ITEMS.tooltip.2=(ɹǝʇsɐɟ) sɯǝʇᴉ pǝddoɹp ᗡᘔ - ʇsɐℲ  
+of.options.DROPPED_ITEMS.tooltip.1=(ɹǝʍoꞁs) sɯǝʇᴉ pǝddoɹp ᗡƐ - ʎɔuɐℲ  
 
 options.entityShadows.tooltip.3=sʍopɐɥS ʎʇᴉʇuƎ
 options.entityShadows.tooltip.2=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs - NO  
@@ -535,7 +546,7 @@ options.entityShadows.tooltip.1=sʍopɐɥs ʎʇᴉʇuǝ ʍoɥs ʇou op - ℲℲO
 
 of.options.VIGNETTE=ǝʇʇǝuᵷᴉΛ
 of.options.VIGNETTE.tooltip.8=sɹǝuɹoɔ uǝǝɹɔs ǝɥʇ suǝʞɹɐp ʎꞁʇɥᵷᴉꞁs ɥɔᴉɥʍ ʇɔǝɟɟǝ ꞁɐnsᴉΛ
-of.options.VIGNETTE.tooltip.7=(ʇꞁnɐɟǝp) sɔᴉɥdɐɹפ ᵷuᴉʇʇǝs ǝɥʇ ʎq ʇǝs sɐ - ʇꞁnɐɟǝp  
+of.options.VIGNETTE.tooltip.7=(ʇꞁnɐɟǝp) sɔᴉɥdɐɹ⅁ ᵷuᴉʇʇǝs ǝɥʇ ʎq ʇǝs sɐ - ʇꞁnɐɟǝᗡ  
 of.options.VIGNETTE.tooltip.6=(ɹǝʇsɐɟ) pǝꞁqɐsᴉp ǝʇʇǝuᵷᴉʌ - ʇsɐℲ  
 of.options.VIGNETTE.tooltip.5=(ɹǝʍoꞁs) pǝꞁqɐuǝ ǝʇʇǝuᵷᴉʌ - ʎɔuɐℲ  
 of.options.VIGNETTE.tooltip.4='SԀℲ ǝɥʇ uo ʇɔǝɟɟǝ ʇuɐɔᴉɟᴉuᵷᴉs ɐ ǝʌɐɥ ʎɐɯ ǝʇʇǝuᵷᴉʌ ǝɥ⟘
@@ -543,11 +554,11 @@ of.options.VIGNETTE.tooltip.3=˙uǝǝɹɔsꞁꞁnɟ ᵷuᴉʎɐꞁd uǝɥʍ ʎ�
 of.options.VIGNETTE.tooltip.2=ʎꞁǝɟɐs uɐɔ puɐ ǝꞁʇqns ʎɹǝʌ sᴉ ʇɔǝɟɟǝ ǝʇʇǝuᵷᴉʌ ǝɥ⟘
 of.options.VIGNETTE.tooltip.1=˙pǝꞁqɐsᴉp ǝq
 
-of.options.DYNAMIC_FOV=ΛoℲ ɔᴉɯɐuʎᗡ
-of.options.DYNAMIC_FOV.tooltip.5=ΛoℲ ɔᴉɯɐuʎᗡ
-of.options.DYNAMIC_FOV.tooltip.4=(ʇꞁnɐɟǝp) ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐuǝ - NO  
-of.options.DYNAMIC_FOV.tooltip.3=ΛoℲ ɔᴉɯɐuʎp ǝꞁqɐsᴉp - ℲℲO  
-of.options.DYNAMIC_FOV.tooltip.2= ᵷuᴉʇuᴉɹds 'ᵷuᴉʎꞁɟ uǝɥʍ (ΛoℲ) ʍǝᴉʌ ɟo pꞁǝᴉɟ ǝɥʇ sǝᵷuɐɥƆ
+of.options.DYNAMIC_FOV=ΛOℲ ɔᴉɯɐuʎᗡ
+of.options.DYNAMIC_FOV.tooltip.5=ΛOℲ ɔᴉɯɐuʎᗡ
+of.options.DYNAMIC_FOV.tooltip.4=(ʇꞁnɐɟǝp) ΛOℲ ɔᴉɯɐuʎp ǝꞁqɐuǝ - NO  
+of.options.DYNAMIC_FOV.tooltip.3=ΛOℲ ɔᴉɯɐuʎp ǝꞁqɐsᴉp - ℲℲO  
+of.options.DYNAMIC_FOV.tooltip.2=ᵷuᴉʇuᴉɹds 'ᵷuᴉʎꞁɟ uǝɥʍ (ΛOℲ) ʍǝᴉʌ ɟo pꞁǝᴉɟ ǝɥʇ sǝᵷuɐɥƆ
 of.options.DYNAMIC_FOV.tooltip.1=˙ʍoq ɐ ᵷuᴉꞁꞁnd ɹo
 
 of.options.DYNAMIC_LIGHTS=sʇɥᵷᴉꞀ ɔᴉɯɐuʎᗡ
@@ -582,12 +593,12 @@ of.options.SMOOTH_WORLD.tooltip.3=uoᴉʇɐsᴉꞁᴉqɐʇs SԀℲ - NO
 of.options.SMOOTH_WORLD.tooltip.2=˙pɐoꞁ ɹǝʌɹǝs ꞁɐuɹǝʇuᴉ ǝɥʇ ᵷuᴉʇnqᴉɹʇsᴉp ʎq SԀℲ sǝsᴉꞁᴉqɐʇS
 of.options.SMOOTH_WORLD.tooltip.1=˙(ɹǝʎɐꞁd ǝꞁᵷuᴉs) spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ʎꞁuo ǝʌᴉʇɔǝɟɟƎ
 
-of.options.FAST_RENDER=ɹǝpuǝɹ ʇsɐℲ
-of.options.FAST_RENDER.tooltip.6=ɹǝpuǝɹ ʇsɐℲ
+of.options.FAST_RENDER=ɹǝpuǝᴚ ʇsɐℲ
+of.options.FAST_RENDER.tooltip.6=ɹǝpuǝᴚ ʇsɐℲ
 of.options.FAST_RENDER.tooltip.5=(ʇꞁnɐɟǝp) ᵷuᴉɹǝpuǝɹ pɹɐpuɐʇs - ℲℲO 
 of.options.FAST_RENDER.tooltip.4=(ɹǝʇsɐɟ) ᵷuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo - NO 
 of.options.FAST_RENDER.tooltip.3=sǝsɐǝɹɔǝp ɥɔᴉɥʍ ɯɥʇᴉɹoᵷꞁɐ ᵷuᴉɹǝpuǝɹ pǝsᴉɯᴉʇdo sǝs∩
-of.options.FAST_RENDER.tooltip.2=˙SԀℲ ǝɥʇ ǝsɐǝɹɔuᴉ ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ puɐ pɐoꞁ ∩Ԁפ ǝɥʇ
+of.options.FAST_RENDER.tooltip.2=˙SԀℲ ǝɥʇ ǝsɐǝɹɔuᴉ ʎꞁꞁɐᴉʇuɐʇsqns ʎɐɯ puɐ pɐoꞁ ∩ԀƆ ǝɥʇ
 of.options.FAST_RENDER.tooltip.1=˙spoɯ ǝɯos ɥʇᴉʍ ʇɔᴉꞁɟuoɔ uɐɔ uoᴉʇdo sᴉɥ⟘
 
 of.options.FAST_MATH=sɥʇɐW ʇsɐℲ
@@ -604,7 +615,7 @@ of.options.CHUNK_UPDATES.tooltip.5=(ʇꞁnɐɟǝp) SԀℲ ɹǝɥᵷᴉɥ 'ᵷu�
 of.options.CHUNK_UPDATES.tooltip.4=SԀℲ ɹǝʍoꞁ 'ᵷuᴉpɐoꞁ pꞁɹoʍ ɹǝʇsɐɟ - Ɛ 
 of.options.CHUNK_UPDATES.tooltip.3=SԀℲ ʇsǝʍoꞁ 'ᵷuᴉpɐoꞁ pꞁɹoʍ ʇsǝʇsɐɟ - ϛ 
 of.options.CHUNK_UPDATES.tooltip.2='ǝɯɐɹɟ pǝɹǝpuǝɹ ɹǝd sǝʇɐpdn ʞunɥɔ ɟo ɹǝqɯnN
-of.options.CHUNK_UPDATES.tooltip.1=˙ǝʇɐɹǝɯɐɹɟ ǝɥʇ ǝzᴉꞁᴉqɐʇsǝp ʎɐɯ sǝnꞁɐʌ ɹǝɥᵷᴉɥ
+of.options.CHUNK_UPDATES.tooltip.1=˙ǝʇɐɹǝɯɐɹɟ ǝɥʇ ǝsᴉꞁᴉqɐʇsǝp ʎɐɯ sǝnꞁɐʌ ɹǝɥᵷᴉɥ
 
 of.options.CHUNK_UPDATES_DYNAMIC=sǝʇɐpd∩ ɔᴉɯɐuʎᗡ
 of.options.CHUNK_UPDATES_DYNAMIC.tooltip.5=sǝʇɐpdn ʞunɥɔ ɔᴉɯɐuʎᗡ
@@ -618,26 +629,26 @@ of.options.LAZY_CHUNK_LOADING.tooltip.7=ᵷuᴉpɐoꞀ ʞunɥƆ ʎzɐꞀ
 of.options.LAZY_CHUNK_LOADING.tooltip.6=ᵷuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʇꞁnɐɟǝp - ℲℲO 
 of.options.LAZY_CHUNK_LOADING.tooltip.5=(ɹǝɥʇooɯs) ᵷuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs ʎzɐꞁ - NO 
 of.options.LAZY_CHUNK_LOADING.tooltip.4=ʎq ᵷuᴉpɐoꞁ ʞunɥɔ ɹǝʌɹǝs pǝʇɐɹᵷǝʇuᴉ ǝɥʇ sɥʇooɯS
-of.options.LAZY_CHUNK_LOADING.tooltip.3=˙sʞɔᴉʇ ꞁɐɹǝʌǝs ɹǝʌo sʞunɥɔ ǝɥʇ ᵷuᴉʇnqᴉɹʇsᴉᗡ
+of.options.LAZY_CHUNK_LOADING.tooltip.3=˙sʞɔᴉʇ ꞁɐɹǝʌǝs ɹǝʌo sʞunɥɔ ǝɥʇ ᵷuᴉʇnqᴉɹʇsᴉp
 of.options.LAZY_CHUNK_LOADING.tooltip.2=˙ʎꞁʇɔǝɹɹoɔ pɐoꞁ ʇou op pꞁɹoʍ ǝɥʇ ɟo sʇɹɐd ɟᴉ ℲℲO ʇᴉ uɹn⟘
 of.options.LAZY_CHUNK_LOADING.tooltip.1=˙(ɹǝʎɐꞁd-ǝꞁᵷuᴉs) spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ʎꞁuo ǝʌᴉʇɔǝɟɟƎ
 
-of.options.RENDER_REGIONS=suoᴉᵷǝɹ ɹǝpuǝᴚ
-of.options.RENDER_REGIONS.tooltip.6=suoᴉᵷǝɹ ɹǝpuǝᴚ
-of.options.RENDER_REGIONS.tooltip.5=(ʇꞁnɐɟǝp) suoᴉᵷǝɹ ɹǝpuǝɹ ǝsn ʇou op - ℲℲO 
-of.options.RENDER_REGIONS.tooltip.4=suoᴉᵷǝɹ ɹǝpuǝɹ ǝsn - NO 
-of.options.RENDER_REGIONS.tooltip.3=ɹǝɥᵷᴉɥ ʇɐ ᵷuᴉɹǝpuǝɹ uᴉɐɹɹǝʇ ɹǝʇsɐɟ ʍoꞁꞁɐ suoᴉᵷǝɹ ɹǝpuǝᴚ
-of.options.RENDER_REGIONS.tooltip.2=˙pǝꞁqɐuǝ ǝɹɐ soqΛ uǝɥʍ ǝʌᴉʇɔǝɟɟǝ ǝɹoW ˙sǝɔuɐʇsᴉp ɹǝpuǝɹ
+of.options.RENDER_REGIONS=suoᴉᵷǝᴚ ɹǝpuǝᴚ
+of.options.RENDER_REGIONS.tooltip.6=suoᴉᵷǝᴚ ɹǝpuǝᴚ
+of.options.RENDER_REGIONS.tooltip.5=(ʇꞁnɐɟǝp) ᵷuᴉɹǝpuǝɹ ɐꞁꞁᴉuɐʌ - ℲℲO 
+of.options.RENDER_REGIONS.tooltip.4=(ɹǝʇsɐɟ) suoᴉᵷǝɹ ɹǝpuǝɹ ǝsn - NO 
+of.options.RENDER_REGIONS.tooltip.3=ᵷuᴉsᴉɯᴉʇdo ʎq ᵷuᴉɹǝpuǝɹ uᴉɐɹɹǝʇ ɹǝʇsɐɟ sʍoꞁꞁⱯ
+of.options.RENDER_REGIONS.tooltip.2=˙sǝɔuɐʇsᴉp ɹǝpuǝɹ ɹǝɥᵷᴉɥ ʇɐ ǝʌᴉʇɔǝɟɟǝ ǝɹoW ˙pɐoꞁ ∩Ԁ⅁ ǝɥʇ
 of.options.RENDER_REGIONS.tooltip.1=˙spɹɐɔ sɔᴉɥdɐɹᵷ pǝʇɐɹᵷǝʇuᴉ ɹoɟ pǝpuǝɯɯoɔǝɹ ʇoN
 
 of.options.SMART_ANIMATIONS=suoᴉʇɐɯᴉuⱯ ʇɹɐɯS
 of.options.SMART_ANIMATIONS.tooltip.7=suoᴉʇɐɯᴉuⱯ ʇɹɐɯS
 of.options.SMART_ANIMATIONS.tooltip.6=(ʇꞁnɐɟǝp) suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn ʇou op - ℲℲO 
-of.options.SMART_ANIMATIONS.tooltip.5=suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn - NO 
-of.options.SMART_ANIMATIONS.tooltip.4= ǝɥʇ ǝʇɐɯᴉuɐ ʎꞁuo ꞁꞁᴉʍ ǝɯɐᵷ ǝɥʇ suoᴉʇɐɯᴉuɐ ʇɹɐɯs ɥʇᴉM
+of.options.SMART_ANIMATIONS.tooltip.5=(ɹǝʇsɐɟ) suoᴉʇɐɯᴉuɐ ʇɹɐɯs ǝsn - NO 
+of.options.SMART_ANIMATIONS.tooltip.4=ǝɥʇ ǝʇɐɯᴉuɐ ʎꞁuo ꞁꞁᴉʍ ǝɯɐᵷ ǝɥʇ suoᴉʇɐɯᴉuɐ ʇɹɐɯs ɥʇᴉM
 of.options.SMART_ANIMATIONS.tooltip.3=˙uǝǝɹɔs ǝɥʇ uo ǝꞁqᴉsᴉʌ ʎꞁʇuǝɹɹnɔ ǝɹɐ ɥɔᴉɥʍ sǝɹnʇxǝʇ
 of.options.SMART_ANIMATIONS.tooltip.2=˙SԀℲ ǝɥʇ sǝsɐǝɹɔuᴉ puɐ sǝʞᴉds ᵷɐꞁ ʞɔᴉʇ ǝɥʇ sǝɔnpǝɹ sᴉɥ⟘
-of.options.SMART_ANIMATIONS.tooltip.1=˙sʞɔɐd ǝɔɹnosǝɹ pH puɐ sʞɔɐd poɯ ᵷᴉq ɹoɟ ꞁnɟǝsn ʎꞁꞁɐᴉɔǝdsƎ
+of.options.SMART_ANIMATIONS.tooltip.1=˙sʞɔɐd ǝɔɹnosǝɹ ᗡH puɐ sʞɔɐd poɯ ᵷᴉq ɹoɟ ꞁnɟǝsn ʎꞁꞁɐᴉɔǝdsƎ
 
 # Animations
 
@@ -673,7 +684,7 @@ of.options.LAGOMETER.tooltip.5=sǝꞁqɐʇnɔǝxǝ pǝꞁnpǝɥɔS - ǝnꞁᗺ *
 of.options.LAGOMETER.tooltip.4=pɐoꞁdn ʞunɥƆ - ǝꞁdɹnԀ *
 of.options.LAGOMETER.tooltip.3=sǝʇɐpdn ʞunɥƆ - pǝᴚ *
 of.options.LAGOMETER.tooltip.2=ʞɔǝɥɔ ʎʇᴉꞁᴉqᴉsᴉΛ - ʍoꞁꞁǝ⅄ *
-of.options.LAGOMETER.tooltip.1=uᴉɐɹɹǝʇ ɹǝpuǝᴚ - uǝǝɹפ *
+of.options.LAGOMETER.tooltip.1=uᴉɐɹɹǝʇ ɹǝpuǝᴚ - uǝǝɹ⅁ *
 
 of.options.PROFILER=ɹǝꞁᴉɟoɹԀ ᵷnqǝᗡ
 of.options.PROFILER.tooltip.5=ɹǝꞁᴉɟoɹԀ ᵷnqǝᗡ
@@ -689,15 +700,15 @@ of.options.WEATHER.tooltip.3=ɹǝʇsɐɟ 'ǝʌᴉʇɔɐ ʇou sᴉ ɹǝɥʇɐǝʍ
 of.options.WEATHER.tooltip.2=˙sɯɹoʇsɹǝpunɥʇ puɐ ʍous 'uᴉɐɹ sꞁoɹʇuoɔ ɹǝɥʇɐǝʍ ǝɥ⟘
 of.options.WEATHER.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ ǝꞁqᴉssod ʎꞁuo sᴉ ꞁoɹʇuoɔ ɹǝɥʇɐǝM
 
-of.options.time.dayOnly=ʎꞁuo ʎɐᗡ
-of.options.time.nightOnly=ʎꞁuo ʇɥᵷᴉN
+of.options.time.dayOnly=ʎꞁuO ʎɐᗡ
+of.options.time.nightOnly=ʎꞁuO ʇɥᵷᴉN
 
 of.options.TIME=ǝɯᴉ⟘
 of.options.TIME.tooltip.6=ǝɯᴉ⟘
-of.options.TIME.tooltip.5=sǝꞁɔʎɔ ʇɥᵷᴉu/ʎɐp ꞁɐɯɹou - ʇꞁnɐɟǝp 
-of.options.TIME.tooltip.4=ʎꞁuo ʎɐp - ʎꞁuo ʎɐᗡ 
-of.options.TIME.tooltip.3=ʎꞁuo ʇɥᵷᴉu - ʎꞁuo ʇɥᵷᴉN 
-of.options.TIME.tooltip.2=ǝpoɯ ƎΛI⟘ⱯƎɹƆ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo sᴉ ᵷuᴉʇʇǝs ǝɯᴉʇ ǝɥ⟘
+of.options.TIME.tooltip.5=sǝꞁɔʎɔ ʇɥᵷᴉu/ʎɐp ꞁɐɯɹou - ʇꞁnɐɟǝᗡ 
+of.options.TIME.tooltip.4=ʎꞁuo ʎɐp - ʎꞁuO ʎɐᗡ 
+of.options.TIME.tooltip.3=ʎꞁuo ʇɥᵷᴉu - ʎꞁuO ʇɥᵷᴉN 
+of.options.TIME.tooltip.2=ǝpoɯ ƎΛI⟘ⱯƎᴚƆ uᴉ ǝʌᴉʇɔǝɟɟǝ ʎꞁuo sᴉ ᵷuᴉʇʇǝs ǝɯᴉʇ ǝɥ⟘
 of.options.TIME.tooltip.1=˙spꞁɹoʍ ꞁɐɔoꞁ ɹoɟ puɐ
 
 options.fullscreen.tooltip.5=uǝǝɹɔsꞁꞁnℲ
@@ -708,7 +719,7 @@ options.fullscreen.tooltip.1=˙pɹɐɔ sɔᴉɥdɐɹᵷ ǝɥʇ uo ᵷuᴉpuǝdǝ
 
 options.fullscreen.resolution=ǝpoW uǝǝɹɔsꞁꞁnℲ
 options.fullscreen.resolution.tooltip.5=ǝpoɯ uǝǝɹɔsꞁꞁnℲ
-options.fullscreen.resolution.tooltip.4=ɹǝʍoꞁs 'uoᴉʇnꞁosǝɹ uǝǝɹɔs doʇʞsǝp ǝsn - ʇꞁnɐɟǝp  
+options.fullscreen.resolution.tooltip.4=ɹǝʍoꞁs 'uoᴉʇnꞁosǝɹ uǝǝɹɔs doʇʞsǝp ǝsn - ʇꞁnɐɟǝᗡ  
 options.fullscreen.resolution.tooltip.3=ɹǝʇsɐɟ ǝq ʎɐɯ 'uoᴉʇnꞁosǝɹ uǝǝɹɔs ɯoʇsnɔ ǝsn - HxM  
 options.fullscreen.resolution.tooltip.2=˙(⥝⥝Ⅎ) ǝpoɯ uǝǝɹɔsꞁꞁnɟ uᴉ pǝsn sᴉ uoᴉʇnꞁosǝɹ pǝʇɔǝꞁǝs ǝɥ⟘
 options.fullscreen.resolution.tooltip.1=˙ɹǝʇsɐɟ ǝq ʎꞁꞁɐɹǝuǝᵷ pꞁnoɥs suoᴉʇnꞁosǝɹ ɹǝʍoꞀ
@@ -737,25 +748,25 @@ of.options.AUTOSAVE_TICKS.tooltip.1=˙pǝuǝdo sᴉ nuǝɯ ǝɯɐᵷ ǝɥʇ uǝ�
 
 of.options.SCREENSHOT_SIZE=ǝzᴉS ʇoɥsuǝǝɹɔS
 of.options.SCREENSHOT_SIZE.tooltip.6=ǝzᴉS ʇoɥsuǝǝɹɔS
-of.options.SCREENSHOT_SIZE.tooltip.5=ǝzᴉs ʇoɥsuǝǝɹɔs ʇꞁnɐɟǝp - ʇꞁnɐɟǝp  
+of.options.SCREENSHOT_SIZE.tooltip.5=ǝzᴉs ʇoɥsuǝǝɹɔs ʇꞁnɐɟǝp - ʇꞁnɐɟǝᗡ  
 of.options.SCREENSHOT_SIZE.tooltip.4=ǝzᴉs ʇoɥsuǝǝɹɔs ɯoʇsnɔ - x߈-xᘔ  
 of.options.SCREENSHOT_SIZE.tooltip.3=˙ʎɹoɯǝɯ ǝɹoɯ pǝǝu ʎɐɯ sʇoɥsuǝǝɹɔs ɹǝᵷᵷᴉq ᵷuᴉɹnʇdɐƆ
-of.options.SCREENSHOT_SIZE.tooltip.2=˙ᵷuᴉsɐᴉꞁɐᴉʇuⱯ puɐ ɹǝpuǝɹ ʇsɐℲ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇoN
-of.options.SCREENSHOT_SIZE.tooltip.1=˙ʇɹoddns ɹǝɟɟnqǝɯɐɹɟ ∩Ԁפ sǝɹᴉnbǝᴚ
+of.options.SCREENSHOT_SIZE.tooltip.2=˙ᵷuᴉsɐᴉꞁɐᴉʇuⱯ ɥʇᴉʍ ǝꞁqᴉʇɐdɯoɔ ʇoN
+of.options.SCREENSHOT_SIZE.tooltip.1=˙ʇɹoddns ɹǝɟɟnqǝɯɐɹɟ ∩Ԁ⅁ sǝɹᴉnbǝᴚ
 
-of.options.SHOW_GL_ERRORS=sɹoɹɹƎ Ꞁפ ʍoɥS
-of.options.SHOW_GL_ERRORS.tooltip.6=sɹoɹɹƎ Ꞁפuǝdo ʍoɥS
-of.options.SHOW_GL_ERRORS.tooltip.5=˙ʇɐɥɔ ǝɥʇ uᴉ uʍoɥs ǝɹɐ sɹoɹɹǝ Ꞁפuǝdo pǝꞁqɐuǝ uǝɥM
+of.options.SHOW_GL_ERRORS=sɹoɹɹƎ Ꞁ⅁ ʍoɥS
+of.options.SHOW_GL_ERRORS.tooltip.6=sɹoɹɹƎ Ꞁ⅁uǝdO ʍoɥS
+of.options.SHOW_GL_ERRORS.tooltip.5=˙ʇɐɥɔ ǝɥʇ uᴉ uʍoɥs ǝɹɐ sɹoɹɹǝ Ꞁ⅁uǝdO pǝꞁqɐuǝ uǝɥM
 of.options.SHOW_GL_ERRORS.tooltip.4=puɐ ʇɔᴉꞁɟuoɔ uʍouʞ ɐ sᴉ ǝɹǝɥʇ ɟᴉ ʎꞁuo ʇᴉ ǝꞁqɐsᴉᗡ
 of.options.SHOW_GL_ERRORS.tooltip.3=˙pǝxᴉɟ ǝq ʇ,uɐɔ sɹoɹɹǝ ǝɥʇ
-of.options.SHOW_GL_ERRORS.tooltip.2= ǝɥʇ uᴉ pǝᵷᵷoꞁ ꞁꞁᴉʇs ǝɹɐ sɹoɹɹǝ ǝɥʇ pǝꞁqɐsᴉp uǝɥM
-of.options.SHOW_GL_ERRORS.tooltip.1= ˙doɹp SԀℲ ʇuɐɔᴉɟᴉuᵷᴉs ɐ ǝsnɐɔ ꞁꞁᴉʇs ʎɐɯ ʎǝɥʇ puɐ ᵷoꞁ ɹoɹɹǝ
+of.options.SHOW_GL_ERRORS.tooltip.2=ǝɥʇ uᴉ pǝᵷᵷoꞁ ꞁꞁᴉʇs ǝɹɐ sɹoɹɹǝ ǝɥʇ pǝꞁqɐsᴉp uǝɥM
+of.options.SHOW_GL_ERRORS.tooltip.1=˙doɹp SԀℲ ʇuɐɔᴉɟᴉuᵷᴉs ɐ ǝsnɐɔ ꞁꞁᴉʇs ʎɐɯ ʎǝɥʇ puɐ ᵷoꞁ ɹoɹɹǝ
 
 # Chat Settings
 
-of.options.CHAT_BACKGROUND=punoɹᵷʞɔɐq ʇɐɥƆ
-of.options.CHAT_BACKGROUND.tooltip.4=punoɹᵷʞɔɐq ʇɐɥƆ
-of.options.CHAT_BACKGROUND.tooltip.3=ɥʇpᴉʍ pǝxᴉɟ - ʇꞁnɐɟǝp  
+of.options.CHAT_BACKGROUND=punoɹᵷʞɔɐᗺ ʇɐɥƆ
+of.options.CHAT_BACKGROUND.tooltip.4=punoɹᵷʞɔɐᗺ ʇɐɥƆ
+of.options.CHAT_BACKGROUND.tooltip.3=ɥʇpᴉʍ pǝxᴉɟ - ʇꞁnɐɟǝᗡ  
 of.options.CHAT_BACKGROUND.tooltip.2=ɥʇpᴉʍ ǝuᴉꞁ sǝɥɔʇɐɯ - ʇɔɐdɯoƆ  
 of.options.CHAT_BACKGROUND.tooltip.1=uǝppᴉɥ - ℲℲO  
 


### PR DESCRIPTION
Added new lines and made changes to match en_us.lang, removed some unnecessary spaces, replaced some characters that displayed lowercase characters where they are supposed to be uppercase (e.g. p ->ᗡ, q -> ᗺ).

Note: `%1$s` and `%2$s` are used to set the order the variables will appear in.