### PR TITLE
Update cem_animation.txt

### DIFF
--- a/OptiFineDoc/doc/cem_animation.txt
+++ b/OptiFineDoc/doc/cem_animation.txt
@@ -116,7 +116,7 @@
 #   exp(x)
 #   frac(x)
 #   log(x)
-#   pow(x)
+#   pow(x,y)
 #   random(x)
 #   round(x)
 #   signum(x)
@@ -134,9 +134,9 @@
 #    "animations":
 #    [
 #      {
-#        "this.rx": "clamp(-0.5 * part.rx, 0, 90)",
+#        "this.rx": "clamp(-0.5 * part.rx, 0, 2*pi)",
 #        "this.tx": "3 * sin(limb_swing / 4) - 2",
-#        "this:Hoof.rx": "if(leg4:Hoof.rx > 90, leg4:Hoof.rx - 90, 0)"
+#        "this:Hoof.rx": "if(leg4:Hoof.rx > 2*pi, leg4:Hoof.rx - 2*pi, 0)"
 #        ...
 #      }
 #    ]


### PR DESCRIPTION
1. pow(x) is not vallid, this will give an error. it should be pow(x,y). because x^y     
2.  the example is somewhat strange:
 Example:
#    ...
#    "animations":
#    [
#      {
#        "this.rx": "clamp(-0.5 * part.rx, 0, 90)",
#        "this.tx": "3 * sin(limb_swing / 4) - 2",
#        "this:Hoof.rx": "if(leg4:Hoof.rx > 90, leg4:Hoof.rx - 90 0)"
#        ...
#      }
#    ]
This is the example, when looking at the rotation you can see its clamped from 0 to 90. This would suggest that the rotation part was written/calculated in Degrees.
but thats not, its calculated in radians. therefor 90 degrees would be 0.5*pi. there for the maximum max you can have is 2*pi