### PR TITLE
Switch to new Minecraft wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,7 +35,7 @@ assignees: ''
 <!-- Any relevant log files. Drag and drop text files here to upload to GitHub directly, OR upload the complete contents to Pastebin. https://pastebin.com/ -->
 
 <!-- You can get logs from `.minecraft/logs`, and crash reports from `.minecraft/crash-reports`. 
-Locating your `.minecraft` folder will depend entirely on your OS. See this page for details: https://minecraft.gamepedia.com/.minecraft -->
+Locating your `.minecraft` folder will depend entirely on your OS. See this page for details: https://minecraft.wiki/w/.minecraft -->
 
 <!-- **DO NOT directly copy and paste log contents here on GitHub.** -->
 

--- a/OptiFineDoc/doc/README.md
+++ b/OptiFineDoc/doc/README.md
@@ -2,6 +2,6 @@
 ## Resource packs
 * Rename folder "assets/minecraft/mcpatcher" to "assets/minecraft/optifine"
 * In all ".properties" files replace references to "assets/minecraft/mcpatcher" with "assets/minecraft/optifine"
-* Replace all numeric IDs (blocks, items, enchantments, etc.) with [names](https://minecraft.fandom.com/wiki/Java_Edition_1.13/Flattening)
+* Replace all numeric IDs (blocks, items, enchantments, etc.) with [names](https://minecraft.wiki/w/Java_Edition_1.13/Flattening)
 ## Shader packs
 * Add mappings for all numeric IDs used in the shader ([blocks](https://github.com/sp614x/optifine/blob/master/OptiFineDoc/doc/shaders.txt#L487), [items](https://github.com/sp614x/optifine/blob/master/OptiFineDoc/doc/shaders.txt#L528), [entities](https://github.com/sp614x/optifine/blob/master/OptiFineDoc/doc/shaders.txt#L543), etc.)

--- a/OptiFineDoc/doc/cit_single.properties
+++ b/OptiFineDoc/doc/cit_single.properties
@@ -60,7 +60,7 @@ items=<list of item IDs>
 texture=<replacement texture>
 
 # (Optional) Replacement model.
-# A json item model in vanilla format (http://minecraft.gamepedia.com/Model#Item_models)
+# A json item model in vanilla format (https://minecraft.wiki/w/Model#Item_models)
 # item/mymodel -> /assets/minecraft/models/item/mymodel.json
 # ./mymodel    -> mymodel.json from the same folder as the properties file
 # The model may reference textures from the same folder, for example: "./mytexture"
@@ -71,10 +71,10 @@ model=<replacement model>
 #
 # For items with durability, damage starts at 0 for a new item and increases as
 # it gets damaged.  The max damage an item can take varies, see
-# http://www.minecraftwiki.net/wiki/Item_durability
+# https://minecraft.wiki/w/Durability
 #
 # For other items, damage represents different properties like potion type or
-# wool color.  See http://www.minecraftwiki.net/wiki/Data_values for specifics.
+# wool color.  See https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening for specifics.
 damage=<damage values 0-65535>
 # Damage can also be given as a percentage: 
 # damage=0-50%
@@ -265,7 +265,7 @@ texture=<replacement texture>
 texture.<name>=<replacement texture>
 
 # (Optional) Replacement model.
-# A json item model in vanilla format (http://minecraft.gamepedia.com/Model#Item_models)
+# A json item model in vanilla format (https://minecraft.wiki/w/Model#Item_models)
 # item/mymodel -> assets/minecraft/models/item/mymodel.json
 # ./mymodel    -> mymodel.json from the same folder as the properties file
 # The model may reference textures from the same folder, for example: "./mytexture"
@@ -365,7 +365,7 @@ weight=<integer>
 # Potions
 ###############################################################################
 
-# http://www.minecraftwiki.net/wiki/Data_values#Potions
+# https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Potions
 # As an alternative to listing potion damage values, you can specify
 # replacement textures for potions using a filename based system.  Note that
 # everything described here CAN be done via cit properties files; this is just

--- a/OptiFineDoc/doc/ctm.properties
+++ b/OptiFineDoc/doc/ctm.properties
@@ -131,7 +131,7 @@ faces=<combination of: north south east west top bottom sides all>
 
 # (Optional) Biome and height restrictions.  
 # Limit only to certain biomes or height ranges.
-# The vanilla biome names are listed here: https://minecraft.gamepedia.com/Biome#Biome_IDs
+# The vanilla biome names are listed here: https://minecraft.wiki/w/Biome#Biome_IDs
 # Biomes added by mods can also be used.
 # The legacy properties "minHeight" and "maxHeight" are also recognized.
 # Since 1.18 negative values may be specified for height. When used in a range they have to be put in brackets.

--- a/OptiFineDoc/doc/custom_guis.properties
+++ b/OptiFineDoc/doc/custom_guis.properties
@@ -99,7 +99,7 @@ texture.<path>=<texture>
 name=<name>
 #
 # Biomes (optional)
-# The vanilla biome names are listed here: https://minecraft.gamepedia.com/Biome#Biome_IDs
+# The vanilla biome names are listed here: https://minecraft.wiki/w/Biome#Biome_IDs
 # Biomes added by mods can also be used.
 biomes=<biome list>
 #

--- a/OptiFineDoc/doc/properties_files.txt
+++ b/OptiFineDoc/doc/properties_files.txt
@@ -92,7 +92,7 @@ so just "stone" will also work. Mods will probably use a namespace other than "m
 See the Dinnerbone's list of Block and Item IDs with names: http://media.dinnerbone.com/uploads/2013-09/files/28_00-44-23_YfmAkomVI.txt
 
 In 1.13 many variant blocks were "flattened" to several simple blocks and the block metadata was removed.
-See https://minecraft.gamepedia.com/1.13/Flattening 
+See https://minecraft.wiki/w/Java_Edition_1.13/Flattening
 
 The block name format is "<namespace:>name<:property1=value1,...:property2=value1,...>". 
 Optional parts are in angle brackets "<>". Default namespace is "minecraft".
@@ -121,14 +121,14 @@ Since 1.7 items can also be specified by name.
 See Dinnerbone's list of Block and Item IDs with names: http://dinnerbone.com/media/uploads/2013-09/files/28_00-44-23_YfmAkomVI.txt
 
 Since 1.13 items can only be specified by name.
-See: https://minecraft.gamepedia.com/1.13/Flattening  
+See: https://minecraft.wiki/w/Java_Edition_1.13/Flattening
 
 Again, the "minecraft:" prefix is optional.
 
 Biomes
 ======
 
-For features that call for a list of biomes, use the names from the Minecraft wiki: https://minecraft.gamepedia.com/Biome#Biome_IDs
+For features that call for a list of biomes, use the names from the Minecraft wiki: https://minecraft.wiki/w/Biome#Biome_IDs
 Biomes added by mods can also be used.
 
   # Biomes short
@@ -137,7 +137,7 @@ Biomes added by mods can also be used.
   biomes=minecraft:ocean biomesoplenty:highland
   
 Since 1.13 many biomes have been renamed.
-See: https://minecraft.gamepedia.com/1.13/Flattening  
+See: https://minecraft.wiki/w/Java_Edition_1.13/Flattening
 
 Blending methods
 ================
@@ -204,4 +204,5 @@ https://bitbucket.org/prupe/mcpatcher/wiki/About_Properties_Files
 http://dinnerbone.com/media/uploads/2013-09/files/28_00-44-23_YfmAkomVI.txt
 http://www.minecraftforum.net/forums/mapping-and-modding/resource-packs/1226351-1?comment=11315
 http://www.minecraftforum.net/forums/mapping-and-modding/resource-packs/1226351-1?comment=11128
-https://minecraft.gamepedia.com/1.13/Flattening
+https://minecraft.wiki/w/Java_Edition_1.13/Flattening
+https://minecraft.wiki/w/Biome#Biome_IDs

--- a/OptiFineDoc/doc/random_entities.properties
+++ b/OptiFineDoc/doc/random_entities.properties
@@ -86,7 +86,7 @@ textures.<n>=<list of texture indices>
 weights.<n>=<same-size list of weights>
 
 # (Optional) List of biomes
-# The vanilla biome names are listed here: https://minecraft.fandom.com/wiki/Biome#Biome_IDs
+# The vanilla biome names are listed here: https://minecraft.wiki/w/Biome#Biome_IDs
 # Biomes added by mods can also be used.
 biomes.<n>=<biome list>
 

--- a/OptiFineDoc/doc/sky.properties
+++ b/OptiFineDoc/doc/sky.properties
@@ -131,7 +131,7 @@ weather=clear|rain|thunder
 
 # (Optional) Biome and height
 # Limit the sky layer to only certain biomes or height ranges.
-# The vanilla biome names are listed here: https://minecraft.gamepedia.com/Biome#Biome_IDs
+# The vanilla biome names are listed here: https://minecraft.wiki/w/Biome#Biome_IDs
 # Biomes added by mods can also be used.
 # Since 1.18 negative values may be specified for height. When used in a range they have to be put in brackets.
 biomes=<biome list>


### PR DESCRIPTION
The minecraft wiki has moved from fandom to minecraft.wiki. This updates all the wiki links to the new wiki