### PR TITLE
added missing parts to doc [head_piglin] left_ear & right_ear

### DIFF
--- a/OptiFineDoc/doc/cem_model.txt
+++ b/OptiFineDoc/doc/cem_model.txt
@@ -71,7 +71,7 @@
 # hanging_sign             board, plank, chains, chain_left1, chain_left2, chain_right1, chain_right2, chains_v
 # head_creeper             head
 # head_dragon              head, jaw
-# head_piglin              head
+# head_piglin              head, left_ear, right_ear
 # head_player              head
 # head_skeleton            head
 # head_wither_skeleton     head


### PR DESCRIPTION
`left_ear` & `right_ear` are both used in the `head_piglin` model but are missing in this doc