### PR TITLE
Fixes #7905

### DIFF
--- a/OptiFineDoc/doc/shaders.txt
+++ b/OptiFineDoc/doc/shaders.txt
@@ -587,10 +587,10 @@ Texture Formats
 1. 8-bit
  Normalized         Signed normalized  Integer            Unsigned integer
  =================  =================  =================  =================
- R8                 R8_SNORM           R8I                R8I
- RG8                RG8_SNORM          RG8I               RG8I
- RGB8               RGB8_SNORM         RGB8I              RGB8I
- RGBA8              RGBA8_SNORM        RGBA8I             RGBA8I
+ R8                 R8_SNORM           R8I                R8UI
+ RG8                RG8_SNORM          RG8I               RG8UI
+ RGB8               RGB8_SNORM         RGB8I              RGB8UI
+ RGBA8              RGBA8_SNORM        RGBA8I             RGBA8UI
 2. 16-bit
  Normalized         Signed normalized  Float              Integer            Unsigned integer
  =================  =================  =================  =================  =================


### PR DESCRIPTION
8-bit Unsigned integer texture formats are confirmed working well, just some mistake in documents

<img width="1920" height="1040" alt="QQ20250907-170739" src="https://github.com/user-attachments/assets/8b7f96fd-d5bb-4bb4-ad99-bd5358efd10e" />
